### PR TITLE
Avoid lua-5.2-only function in tangle.lua

### DIFF
--- a/tangle.lua
+++ b/tangle.lua
@@ -43,7 +43,8 @@ function Doc(body, metadata, variables)
   local targets = split_classes(metadata.code or '')
   local block = 1
   local function replace()
-    classes, code = table.unpack(blocks[block])
+    local classes = blocks[block][1]
+    local code = blocks[block][2]
     block = block + 1
     if keep(classes,targets) then
       return code


### PR DESCRIPTION
It turns out table.unpack was added in 5.2 and the
pandoc distributed in Ubuntu 14.04 was built with 5.1