### PR TITLE
Assembler

### DIFF
--- a/compiler/app/Main.hs
+++ b/compiler/app/Main.hs
@@ -17,7 +17,7 @@ import Text.Parsec (parse)
 import Text.Parsec.String (Parser)
 import System.Environment
 
-import IeleParser (ieleParser1)
+import IeleParser (ieleParser)
 import IeleAssembler (assemble)
 import IeleTypes
 import IelePrint
@@ -93,16 +93,16 @@ main = do
   case args of
     [file] -> do
       contents <- readFile file
-      case parse ieleParser1 file contents of
+      case parse ieleParser file contents of
         Left err  -> print err
-        Right c  -> do
+        Right cs  -> do
           {-
           writeFile "test1.iele" (show (prettyContract c))
           let (defs,c') = processContract c
           mapM_ print defs
           writeFile "test2.iele" (show (prettyContract c'))
            -}
-          B.putStr . b16Enc . assemble . compileContract $ c
+          B.putStr . b16Enc . assemble . compileContracts $ cs
     _ -> putStrLn "Usage: iele-assemble FILE"
 
 --parse anyChar "" "a"

--- a/compiler/compiler.cabal
+++ b/compiler/compiler.cabal
@@ -26,6 +26,7 @@ library
                      , parsec >=3.1 && <3.2
                      , containers
                      , lens
+                     , bifunctors
                      , validation
                      , cereal
                      , bytestring

--- a/compiler/src/IeleAssembler.hs
+++ b/compiler/src/IeleAssembler.hs
@@ -54,9 +54,6 @@ asm_iele_opcode1 op1 = case op1 of
 
   MOVE -> putWord8 0x60
 
-  CREATE contract nargs -> putWord8 0xf0 >> putWord16be contract >> putArgs16 nargs
-  COPYCREATE nargs -> putWord8 0xf1 >> putArgs16 nargs
-
   IeleOpcodesQuery queryOp -> putWord8 $ case queryOp of
     ADDRESS -> 0x30
     BALANCE -> 0x31
@@ -109,11 +106,14 @@ asm_iele_opcode_li opLi = case opLi of
   LOADPOS -> putWord8 0x61
   LOADNEG -> putWord8 0x62
 
-asm_iele_opcode_call :: IeleOpcodeCall Word16 -> Put
+asm_iele_opcode_call :: IeleOpcodeCall Word16 Word16 -> Put
 asm_iele_opcode_call opCall = case opCall of
   CALL call nargs nreturn -> putWord8 0xf2 >> putWord16be call >> putArgs16 nargs >> putRets16 nreturn
   STATICCALL call nargs nreturn -> putWord8 0xf5 >> putWord16be call >> putArgs16 nargs >> putRets16 nreturn
   LOCALCALL call nargs nreturn -> putWord8 0xf8 >> putWord16be call >> putArgs16 nargs >> putRets16 nreturn
+
+  CREATE contract nargs -> putWord8 0xf0 >> putWord16be contract >> putArgs16 nargs
+  COPYCREATE nargs -> putWord8 0xf1 >> putArgs16 nargs
 
 -- Register numbers are packed bitwise
 asm_iele_regs :: Word8 -> [Int] -> Put

--- a/compiler/src/IeleAssembler.hs
+++ b/compiler/src/IeleAssembler.hs
@@ -94,8 +94,8 @@ asm_iele_opcode0 op0 = case op0 of
   LOG n | n <= 4 -> putWord8 (0xa0 + n)
         | otherwise -> error "LOG only takes up to 4 values"
 
-  RETURN nreturn -> putWord8 0xf6 >> putWord16be (retsCount nreturn)
-  REVERT nreturn -> putWord8 0xf7 >> putWord16be (retsCount nreturn)
+  RETURN nargs -> putWord8 0xf6 >> putArgs16 nargs
+  REVERT nargs -> putWord8 0xf7 >> putArgs16 nargs
 
   INVALID -> putWord8 0xfe
 

--- a/compiler/src/IeleDesugar.hs
+++ b/compiler/src/IeleDesugar.hs
@@ -9,6 +9,8 @@ import qualified Data.Set as Set
 import Data.Map.Strict(Map,(!))
 import qualified Data.Map.Strict as Map
 
+import Data.Bifunctor
+
 import Data.Word
 import Data.Data
 
@@ -116,12 +118,11 @@ flattenInsts = map flattenInst
 
 flattenInst :: Instruction -> IeleOp'
 flattenInst Nop = Nop
-flattenInst (Op op1 result args) = Op (fmap flattenName op1) result args
-flattenInst (VoidOp op0 args) = VoidOp (flattenOp0 op0) args
-  where flattenOp0 op = op & relabelOpcode0 pure %~ flattenName
-                           & flip relabelOpcode0 pure %~ flattenGlobalName
+flattenInst (Op op1 result args) = Op op1 result args
+flattenInst (VoidOp op0 args) =
+  VoidOp (bimap flattenGlobalName flattenName op0) args
 flattenInst (CallOp callOp results args) =
-  CallOp (fmap flattenGlobalName callOp) results args
+  CallOp (bimap flattenName flattenGlobalName callOp) results args
 flattenInst (LiOp op result val) = LiOp op result val
 
 flattenName :: IeleName -> Word16

--- a/compiler/src/IeleDesugar.hs
+++ b/compiler/src/IeleDesugar.hs
@@ -1,13 +1,11 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module IeleDesugar where
-import IeleTypes
-import IeleInstructions
-
 import Data.IntSet(IntSet)
 import qualified Data.IntSet as IntSet
 import qualified Data.Set as Set
 import Data.Map.Strict(Map,(!))
 import qualified Data.Map.Strict as Map
+import qualified Data.ByteString as B
 
 import Data.Bifunctor
 
@@ -16,6 +14,11 @@ import Data.Data
 
 import Control.Lens
 import Data.Data.Lens
+
+import IeleInstructions
+import IeleAssembler
+import IeleTypes
+import IelePrint(prettyInst)
 
 type IeleNameNum = Int
 
@@ -66,12 +69,22 @@ numberLocals funDef =
   in funDef & funParams %~ rename
             & funLocalRegs %~ rename
 
-numberGlobals :: Contract -> Contract
-numberGlobals contract =
-  let globalRegs :: Traversal' Contract IeleName
-      globalRegs = template . _LValueGlobalName . _GlobalName
-      rename = applyIeleNameMap (numberIeleNames (contract ^.. globalRegs))
-  in contract & template . _LValueGlobalName . _GlobalName %~ rename
+expandGlobals :: Contract -> Contract
+expandGlobals contract =
+  let globalVals = Map.fromList [(g,val) | TopLevelDefinitionGlobal g val <-
+                                    contractDefinitions contract]
+      definitions = [d | d <- contractDefinitions contract,
+                         case d of {TopLevelDefinitionGlobal _ _ -> False; _ -> True}]
+      desugarLoadGlobal :: Instruction -> Instruction
+      desugarLoadGlobal i@(SugarInst (LoadGlobal dest g))
+        | Just v <- Map.lookup g globalVals =
+            if v >= 0
+            then IeleInst (LiOp LOADPOS dest v)
+            else IeleInst (LiOp LOADNEG dest (abs v))
+        | otherwise = error $ "attempting to load unknown global in "++show (prettyInst i)
+      desugarLoadGlobal i = i
+  in contract {contractDefinitions = definitions}
+        & template %~ desugarLoadGlobal
 
 functionDefinitions :: Traversal' Contract FunctionDefinition
 functionDefinitions = template
@@ -82,21 +95,31 @@ calledFunctions = template . instructionCallName . _GlobalName
 declaredFunctions :: Traversal' Contract IeleName
 declaredFunctions = functionDefinitions . name . _GlobalName
 
-numberFunctions :: Contract -> ([IeleName],Contract)
-numberFunctions contract = let
+createdContracts :: Traversal' Contract IeleName
+createdContracts = template . instructionContractName
+
+numberDecls :: Contract -> ([IeleName],[IeleName],[FunctionDefinition])
+numberDecls contract = let
   funNames = contract ^.. declaredFunctions ++ contract ^.. calledFunctions
   funDecls = Set.delete (IeleNameText "init") (Set.fromList funNames)
+  contractDecls = [name | TopLevelDefinitionContract name <- contractDefinitions contract]
   functionTable = Set.toList funDecls
   functionMapping = Map.insert (IeleNameText "init") (IeleNameNumber 0)
       (Map.fromList (zip functionTable (map IeleNameNumber [1..])))
+  contractNums = map IeleNameNumber [1 + length functionTable..]
+  contractMapping = Map.fromList (zip contractDecls contractNums)
  in (functionTable,
+     contractDecls,
+     toListOf functionDefinitions $
       contract & calledFunctions %~ (functionMapping !)
-               & declaredFunctions %~ (functionMapping !))
+               & declaredFunctions %~ (functionMapping !)
+               & createdContracts %~ (contractMapping !))
 
-processContract :: Contract -> ([IeleName],Contract)
+processContract :: Contract -> ([IeleName],[IeleName],[FunctionDefinition])
 processContract contract =
-  let locallyNumbered = contract & functionDefinitions  %~ numberLocals . numberBlocks
-  in numberFunctions (numberGlobals locallyNumbered)
+  let (funDecls,contractDecls,funDefs) = numberDecls (expandGlobals contract)
+      numberedFuns = map (numberLocals . numberBlocks) funDefs
+  in  (funDecls,contractDecls,numberedFuns)
 
 type IeleOp' = IeleOpG Word16 Word16 Word16 LValue
 
@@ -117,13 +140,17 @@ flattenInsts :: [Instruction] -> [IeleOp']
 flattenInsts = map flattenInst
 
 flattenInst :: Instruction -> IeleOp'
-flattenInst Nop = Nop
-flattenInst (Op op1 result args) = Op op1 result args
-flattenInst (VoidOp op0 args) =
+flattenInst (IeleInst i) = flattenIeleInst i
+flattenInst (SugarInst s) = error "sugar-only instructions should have been expanded by now"
+
+flattenIeleInst :: IeleOpP -> IeleOp'
+flattenIeleInst Nop = Nop
+flattenIeleInst (Op op1 result args) = Op op1 result args
+flattenIeleInst (VoidOp op0 args) =
   VoidOp (bimap flattenGlobalName flattenName op0) args
-flattenInst (CallOp callOp results args) =
+flattenIeleInst (CallOp callOp results args) =
   CallOp (bimap flattenName flattenGlobalName callOp) results args
-flattenInst (LiOp op result val) = LiOp op result val
+flattenIeleInst (LiOp op result val) = LiOp op result val
 
 flattenName :: IeleName -> Word16
 flattenName (IeleNameNumber i) = fromIntegral i
@@ -132,24 +159,35 @@ flattenName (IeleNameText t) = error $ "residual text name "++t
 flattenGlobalName :: GlobalName -> Word16
 flattenGlobalName (GlobalName i) = flattenName i
 
+neededBits :: Integral a => a -> Int
+neededBits max = ceiling (logBase 2 (fromIntegral max+1))
+
 countRegisters :: [IeleOp'] -> [IeleOp]
 countRegisters ops' =
   let maxRegs = maximumOf (traverse . traverse . to regNum) ops'
       nbits = case maxRegs of
         Nothing -> 0
-        Just maxNum -> 1 + ceiling (logBase 2 (fromIntegral maxNum))
-      globalOffset = 2^(nbits-1)
+        Just maxNum -> neededBits maxNum
       regNum (LValueLocalName (LocalName (IeleNameNumber i))) = i
-      regNum (LValueGlobalName (GlobalName (IeleNameNumber i))) = i
       regNum l = error $ "Residual textual name "++show l
       valToInt (LValueLocalName (LocalName (IeleNameNumber i))) = i
-      valToInt (LValueGlobalName (GlobalName (IeleNameNumber i))) = globalOffset + i
   in [VoidOp (REGISTERS (fromIntegral nbits)) []]
      ++ over (traverse . traverse) valToInt ops'
 
-compileContract :: Contract -> [IeleOp]
-compileContract contract =
-  let (functions,Contract _ _ defs) = processContract contract
+compileContract :: Map IeleName B.ByteString -> Contract -> [IeleOp]
+compileContract childContracts contract =
+  let (functions,contracts,fundefs) = processContract contract
       ops' = [VoidOp (FUNCTION t) [] | IeleNameText t <- functions]
-             ++ concatMapOf (traverse . _TopLevelDefinitionFunction) flattenFundef defs
+             ++ [VoidOp (CONTRACT (childContracts ! c)) [] | c <- contracts]
+             ++ concatMap flattenFundef fundefs
   in countRegisters ops'
+
+compileContracts :: [Contract] -> [IeleOp]
+compileContracts [] = []
+compileContracts (c:cs) = go Map.empty c cs
+  where go childContracts main [] = compileContract childContracts main
+        go childContracts c (c':cs) =
+          go (Map.insert (contractName c)
+                         (assemble (compileContract childContracts c))
+                         childContracts)
+             c' cs

--- a/compiler/src/IeleInstructions.hs
+++ b/compiler/src/IeleInstructions.hs
@@ -123,8 +123,8 @@ data IeleOpcode0G funId lblId =
 
  | LOG Word8
 
- | RETURN (Rets Word16)
- | REVERT (Rets Word16)
+ | RETURN (Args Word16)
+ | REVERT (Args Word16)
 
  | INVALID
  | SELFDESTRUCT

--- a/compiler/src/IeleParserImplementation.hs
+++ b/compiler/src/IeleParserImplementation.hs
@@ -404,11 +404,10 @@ argumentsOrVoid = nonEmptyLValues <|> [] <$ skipKeyword "void"
 
 returnInst :: Parser IeleOpP
 returnInst = skipKeyword "ret" *>
-  fmap (\args -> VoidOp (RETURN (retsLength args)) args) argumentsOrVoid
+  fmap (\args -> VoidOp (RETURN (argsLength args)) args) argumentsOrVoid
 
 revertInst :: Parser IeleOpP
-revertInst = skipKeyword "revert" *>
-  fmap (\args -> VoidOp (REVERT (retsLength args)) args) argumentsOrVoid
+revertInst = simpleOp0 "revert" 1 (REVERT (mkArgs 1))
 
 selfDestructInst :: Parser IeleOpP
 selfDestructInst = simpleOp0 "selfdestruct" 1 SELFDESTRUCT

--- a/compiler/src/IeleTypes.hs
+++ b/compiler/src/IeleTypes.hs
@@ -17,7 +17,6 @@ module IeleTypes
     -- type synonyms for parser's instantiations of IeleInstructions' types
     , Instruction
     , IeleOpcode0P
-    , IeleOpcode1P
 
     , HasName(name)
     , HasSize(size)
@@ -49,7 +48,6 @@ import Control.Lens
 import IeleInstructions
 
 type Instruction = IeleOpG IeleName GlobalName IeleName LValue
-type IeleOpcode1P = IeleOpcode1G IeleName
 type IeleOpcode0P = IeleOpcode0G GlobalName IeleName
 
 data IeleName = IeleNameNumber Int | IeleNameText String

--- a/compiler/src/IeleTypes.hs
+++ b/compiler/src/IeleTypes.hs
@@ -10,12 +10,14 @@ module IeleTypes
     , LabeledBlock (LabeledBlock, labeledBlockLabel, labeledBlockInstructions)
     , GlobalName (GlobalName)
     , LocalName (LocalName)
-    , LValue (LValueGlobalName, LValueLocalName)
+    , LValue (LValueLocalName)
     , TopLevelDefinition
-      (TopLevelDefinitionContract, TopLevelDefinitionFunction)
+      (TopLevelDefinitionContract, TopLevelDefinitionFunction, TopLevelDefinitionGlobal)
 
     -- type synonyms for parser's instantiations of IeleInstructions' types
-    , Instruction
+    , Instruction(IeleInst,SugarInst)
+    , SugarInstruction(LoadGlobal)
+    , IeleOpP
     , IeleOpcode0P
 
     , HasName(name)
@@ -28,13 +30,13 @@ module IeleTypes
     , HasLabel(label)
     , HasInstructions(instructions)
     , _LValueLocalName
-    , _LValueGlobalName
     , _LocalName
     , _GlobalName
     , _TopLevelDefinitionFunction
     , instructionRegisters
     , instructionJumpDest
     , instructionCallName
+    , instructionContractName
     , functionInsts
     ) where
 import Data.Char
@@ -47,8 +49,17 @@ import Control.Lens
 
 import IeleInstructions
 
-type Instruction = IeleOpG IeleName GlobalName IeleName LValue
+type IeleOpP = IeleOpG IeleName GlobalName IeleName LValue
 type IeleOpcode0P = IeleOpcode0G GlobalName IeleName
+
+data Instruction =
+   IeleInst IeleOpP
+ | SugarInst SugarInstruction
+  deriving (Show, Eq, Data)
+
+data SugarInstruction =
+  LoadGlobal LValue GlobalName
+  deriving (Show, Eq, Data)
 
 data IeleName = IeleNameNumber Int | IeleNameText String
   deriving (Show, Eq, Ord, Data)
@@ -82,13 +93,10 @@ instance IsString LocalName where
   fromString ('%':str) = LocalName (fromString str)
   fromString str = error $ "LocalName must begin with % in "++show str
 
-data LValue =
-    LValueGlobalName GlobalName
-  | LValueLocalName LocalName
+newtype LValue = LValueLocalName LocalName
   deriving (Show, Eq, Data)
 
 instance IsString LValue where
-  fromString str@('@':_) = LValueGlobalName (fromString str)
   fromString str@('%':_) = LValueLocalName (fromString str)
   fromString str = error $ "LValue must begin with % or @ in "++show str
 
@@ -105,8 +113,9 @@ data FunctionDefinition = FunctionDefinition
   , functionDefinitionBlocks :: [LabeledBlock]
   } deriving (Show, Eq, Data)
 data TopLevelDefinition =
-    TopLevelDefinitionContract GlobalName
+    TopLevelDefinitionContract IeleName
   | TopLevelDefinitionFunction FunctionDefinition
+  | TopLevelDefinitionGlobal GlobalName Integer
   deriving (Show, Eq, Data)
 data Contract = Contract
   { contractName :: IeleName
@@ -119,15 +128,21 @@ instructionRegisters :: Traversal' Instruction LValue
 instructionRegisters = template
 
 instructionJumpDest :: Traversal' Instruction IeleName
-instructionJumpDest f (VoidOp (JUMP tgt) [])
-  = fmap (\tgt -> VoidOp (JUMP tgt) []) (f tgt)
-instructionJumpDest f (VoidOp (JUMPI tgt) [arg])
-  = fmap (\tgt -> VoidOp (JUMPI tgt) [arg]) (f tgt)
+instructionJumpDest f (IeleInst (VoidOp (JUMP tgt) []))
+  = fmap (\tgt -> IeleInst (VoidOp (JUMP tgt) [])) (f tgt)
+instructionJumpDest f (IeleInst (VoidOp (JUMPI tgt) [arg]))
+  = fmap (\tgt -> IeleInst (VoidOp (JUMPI tgt) [arg])) (f tgt)
 instructionJumpDest _ i = pure i
 
-instructionCallName :: Traversal' Instruction GlobalName
-instructionCallName f (CallOp callOp results args) = (\o' -> CallOp o' results args) <$> traverse f callOp
+instructionCallName :: Traversal' IeleOpP GlobalName
+instructionCallName f (CallOp callOp results args) =
+  (\o' -> CallOp o' results args) <$> traverse f callOp
 instructionCallName _ inst = pure inst
+
+instructionContractName :: Traversal' IeleOpP IeleName
+instructionContractName f (CallOp (CREATE c nargs) results args) =
+  fmap (\c' -> CallOp (CREATE c' nargs) results args) (f c)
+instructionContractName _ inst = pure inst
 
 functionInsts :: Traversal' FunctionDefinition Instruction
 functionInsts = template

--- a/compiler/test/TestParser.hs
+++ b/compiler/test/TestParser.hs
@@ -322,12 +322,12 @@ instructionTests =
       (parseFailure (instruction <* eof) "log %idx, %1, %2, %3, %4, %5")
   , testInstruction
       "create"
-      (Op (CREATE "b" (mkArgs 2)) "%a" ["%12","%10","%11"])
-      "%a=create b(%10,%11) send %12"
+      (CallOp (CREATE "b" (mkArgs 2)) ["%a","%b"] ["%12","%10","%11"])
+      "%a,%b=create b(%10,%11) send %12"
   , testInstruction
       "copycreate"
-      (Op (COPYCREATE (mkArgs 2)) "%a" ["%val","%acct","%10","%11"])
-      "%a=copycreate %acct(%10,%11) send %val"
+      (CallOp (COPYCREATE (mkArgs 2)) ["%a","%b"] ["%val","%acct","%10","%11"])
+      "%a,%b=copycreate %acct(%10,%11) send %val"
   , testInstruction
       "SelfDestruct"
       (VoidOp SELFDESTRUCT ["%10"])
@@ -461,21 +461,21 @@ parseFailure parser input =
 -- Instruction test utilities
 ------------------------------------
 
-testBinaryOperation :: String -> IeleOpcode1P ->  TestTree
+testBinaryOperation :: String -> IeleOpcode1 ->  TestTree
 testBinaryOperation name op =
   testInstruction
     name
     (Op op "%a" ["%10","@b"])
     ("%a=" ++ name ++ " %10,@b")
 
-testPredicateOperation :: String -> IeleOpcode1P ->  TestTree
+testPredicateOperation :: String -> IeleOpcode1 ->  TestTree
 testPredicateOperation name op =
   testInstruction
     name
     (Op op "%a" ["%10","@11"])
     ("%a=cmp " ++ name ++ " %10,@11")
 
-testTernaryOperation :: String -> IeleOpcode1P ->  TestTree
+testTernaryOperation :: String -> IeleOpcode1 ->  TestTree
 testTernaryOperation name op =
   testInstruction
     name

--- a/compiler/test/TestParser.hs
+++ b/compiler/test/TestParser.hs
@@ -21,7 +21,7 @@ main =
       "All Tests"
       [ testGroup "Token Tests" tokenTests
       , testGroup "Instruction Tests" instructionTests
---      , testGroup "Other Tests" otherTests
+      , testGroup "Other Tests" otherTests
       ]
     )
 
@@ -86,18 +86,16 @@ localNameCounterexamples =
 lValueExamples :: [(LValue, String)]
 lValueExamples =
   [ (LValueLocalName (LocalName (IeleNameText "a")), "%a")
-  , (LValueGlobalName (GlobalName (IeleNameText "a")), "@a")
   ]
 
 lValueCounterexamples :: [String]
 lValueCounterexamples =
-  ["%", "a", "@"]
+  ["%", "@a", "a", "@"]
 
 nonEmptyLValuesExamples :: [([LValue], String)]
 nonEmptyLValuesExamples =
     [ ([LValueLocalName "%a"], "%a")
-    , ([LValueLocalName "%a", LValueGlobalName "@b"], "%a,@b")
-    , ([LValueGlobalName "@a", LValueLocalName "%b"], "@a, %b")
+    , ([LValueLocalName "%a", LValueLocalName "%b"], "%a, %b")
     ]
 
 nonEmptyLValuesCounterexamples :: [String]
@@ -107,19 +105,19 @@ nonEmptyLValuesCounterexamples =
 lvaluesExamples :: [([LValue], String)]
 lvaluesExamples =
   [ ([LValueLocalName "%a"], "%a")
-  , ([LValueLocalName "%a", LValueGlobalName "@b"], "%a,@b")
-  , ([LValueGlobalName "@a", LValueLocalName "%b"], "@a, %b")
+  , ([LValueLocalName "%a", LValueLocalName "%b"], "%a,%b")
+  , ([LValueLocalName "%a", LValueLocalName "%b"], "%a, %b")
   , ([], "")
   ]
 
 lvaluesCounterexamples :: [String]
 lvaluesCounterexamples =
-  ["%", "@"]
+  ["%", "@", "@a"]
 
 
 nonEmptyOperandsCounterexamples :: [String]
 nonEmptyOperandsCounterexamples =
-    ["%", "@", ""]
+    ["%", "@", "", "@a"]
 
 functionParametersExamples :: [([LocalName], String)]
 functionParametersExamples =
@@ -161,47 +159,47 @@ tokenTests =
 
 instructionTests :: [TestTree]
 instructionTests =
-  [ testInstruction
+  [ testIeleInst
       "Load Immediate Pos"
       (LiOp LOADPOS "%a" 10)
       "%a=10"
-  , testInstruction
+  , testIeleInst
       "Load Immediate Neg"
       (LiOp LOADNEG "%a" 10)
       "%a=-10"
-  , testInstruction
+  , testIeleInst
       "Move"
-      (Op  MOVE "%a" ["@b"])
-      "%a=@b"
-  , testInstruction
+      (Op  MOVE "%a" ["%b"])
+      "%a=%b"
+  , testIeleInst
       "Load"
       (Op MLOAD "%a" ["%10"])
       "%a=load %10"
-  , testInstruction
+  , testIeleInst
       "LoadN"
       (Op MLOADN "%a" ["%10","%off","%size"])
       "%a=load %10, %off, %size"
-  , testInstruction
+  , testIeleInst
       "Store"
       (VoidOp MSTORE ["%9","%10"])
       "store %9, %10"
-  , testInstruction
+  , testIeleInst
       "StoreN"
       (VoidOp MSTOREN ["%9","%10","%off","%size"])
       "store %9, %10, %off, %size"
-  , testInstruction
+  , testIeleInst
       "SLoad"
       (Op SLOAD "%a" ["%10"])
       "%a=sload %10"
-  , testInstruction
+  , testIeleInst
       "SStore"
       (VoidOp SSTORE ["%9","%10"])
       "sstore %9, %10"
-  , testInstruction
+  , testIeleInst
       "IsZero"
       (Op ISZERO "%a" ["%10"])
       "%a=iszero %10"
-  , testInstruction
+  , testIeleInst
       "Not"
       (Op NOT "%a" ["%b"])
       "%a = not %b"
@@ -231,104 +229,104 @@ instructionTests =
   , testPredicateOperation "eq" EQ
   , testPredicateOperation "ne" NE
 
-  , testInstruction "sha3"
+  , testIeleInst "sha3"
       (Op SHA3 "%a" ["%b"])
       "%a = sha3 %b"
 
-  , testInstruction
+  , testIeleInst
       "Jump"
       (VoidOp (JUMP "a") [])
       "br a"
-  , testInstruction
+  , testIeleInst
       "CondJump"
       (VoidOp (JUMPI "a") ["%10"])
       "br %10, a"
 
-  , testInstruction
+  , testIeleInst
       "LocalCall"
-      (CallOp (LOCALCALL "@c" (mkArgs 2) (mkRets 2)) ["%a","@b"] ["%10","%11"])
-      "%a,@b=call@c(%10,%11)"
-  , testInstruction
+      (CallOp (LOCALCALL "@c" (mkArgs 2) (mkRets 2)) ["%a","%b"] ["%10","%11"])
+      "%a,%b=call@c(%10,%11)"
+  , testIeleInst
       "empty arguments LocalCall"
-      (CallOp (LOCALCALL "@c" (mkArgs 0) (mkRets 2)) ["%a","@b"] [])
-      "%a,@b=call@c()"
-  , testInstruction
+      (CallOp (LOCALCALL "@c" (mkArgs 0) (mkRets 2)) ["%a","%b"] [])
+      "%a,%b=call@c()"
+  , testIeleInst
       "empty results LocalCall"
       (CallOp (LOCALCALL "@c" (mkArgs 2) (mkRets 0)) [] ["%10","%11"])
       "call@c(%10,%11)"
-  , testInstruction
+  , testIeleInst
       "empty lvalues arguments LocalCall"
       (CallOp (LOCALCALL "@c" (mkArgs 0) (mkRets 0)) [] [])
       "call@c()"
 
-  , testInstruction
+  , testIeleInst
       "AccountCall"
-      (CallOp (CALL "@c" (mkArgs 2) (mkRets (3-1))) ["%ok","%a","@b"] ["%gas","%acct","%amt","%10","%11"])
-      "%ok,%a,@b=call@c at %acct(%10,%11)send %amt, gaslimit %gas"
-  , testInstruction
+      (CallOp (CALL "@c" (mkArgs 2) (mkRets (3-1))) ["%ok","%a","%b"] ["%gas","%acct","%amt","%10","%11"])
+      "%ok,%a,%b=call@c at %acct(%10,%11)send %amt, gaslimit %gas"
+  , testIeleInst
       "empty arguments AccountCall"
-      (CallOp (CALL "@c" (mkArgs 0) (mkRets (2-1))) ["%ok","@b"] ["%gas","%acct","%amt"])
-      "%ok , @b = call @c at %acct() send %amt, gaslimit %gas"
-  , testInstruction
+      (CallOp (CALL "@c" (mkArgs 0) (mkRets (2-1))) ["%ok","%b"] ["%gas","%acct","%amt"])
+      "%ok , %b = call @c at %acct() send %amt, gaslimit %gas"
+  , testIeleInst
       "StaticCall"
-      (CallOp (STATICCALL "@c" (mkArgs 2) (mkRets (3-1))) ["%ok","%a","@b"] ["%gas","%acct","%amt","%10","%11"])
-      "%ok,%a,@b=staticcall@c at %acct(%10,%11)send %amt, gaslimit %gas"
-  , testInstruction
+      (CallOp (STATICCALL "@c" (mkArgs 2) (mkRets (3-1))) ["%ok","%a","%b"] ["%gas","%acct","%amt","%10","%11"])
+      "%ok,%a,%b=staticcall@c at %acct(%10,%11)send %amt, gaslimit %gas"
+  , testIeleInst
       "empty arguments StaticCall"
-      (CallOp (STATICCALL "@c" (mkArgs 0) (mkRets (2-1))) ["%ok","@b"] ["%gas","%acct","%amt"])
-      "%ok , @b = staticcall @c at %acct() send %amt, gaslimit %gas"
+      (CallOp (STATICCALL "@c" (mkArgs 0) (mkRets (2-1))) ["%ok","%b"] ["%gas","%acct","%amt"])
+      "%ok , %b = staticcall @c at %acct() send %amt, gaslimit %gas"
   , testCase
       "reject empty lvalues AccountCall"
       (parseFailure instruction
         "call@c at %acct(%10,%11)send %amt, gaslimit %gas")
-  , testInstruction
+  , testIeleInst
       "Return"
-      (VoidOp (RETURN (mkRets 2)) ["@10","%11"])
-      "ret @10, %11"
-  , testInstruction
+      (VoidOp (RETURN (mkRets 2)) ["%10","%11"])
+      "ret %10, %11"
+  , testIeleInst
       "empty Return"
       (VoidOp (RETURN (mkRets 0)) [])
       "ret void"
-  , testInstruction
+  , testIeleInst
       "Revert"
-      (VoidOp (REVERT (mkRets 2)) ["%10","@11"])
-      "revert %10, @11"
-  , testInstruction
+      (VoidOp (REVERT (mkRets 2)) ["%10","%11"])
+      "revert %10, %11"
+  , testIeleInst
       "empty Revert"
       (VoidOp (REVERT (mkRets 0)) [])
       "revert void"
-  , testInstruction
+  , testIeleInst
       "Log 0"
       (VoidOp (LOG 0) ["%idx"])
       "log %idx"
-  , testInstruction
+  , testIeleInst
       "Log 1"
       (VoidOp (LOG 1) ["%idx","%1"])
       "log %idx, %1"
-  , testInstruction
+  , testIeleInst
       "Log 2"
       (VoidOp (LOG 2) ["%idx","%1","%2"])
       "log %idx, %1, %2"
-  , testInstruction
+  , testIeleInst
       "Log 3"
       (VoidOp (LOG 3) ["%idx","%1","%2","%3"])
       "log %idx, %1, %2, %3"
-  , testInstruction
+  , testIeleInst
       "Log 4"
       (VoidOp (LOG 4) ["%idx","%1","%2","%3","%4"])
       "log %idx, %1, %2, %3, %4"
   , testCase
       "Reject Log 5"
       (parseFailure (instruction <* eof) "log %idx, %1, %2, %3, %4, %5")
-  , testInstruction
+  , testIeleInst
       "create"
       (CallOp (CREATE "b" (mkArgs 2)) ["%a","%b"] ["%12","%10","%11"])
       "%a,%b=create b(%10,%11) send %12"
-  , testInstruction
+  , testIeleInst
       "copycreate"
       (CallOp (COPYCREATE (mkArgs 2)) ["%a","%b"] ["%val","%acct","%10","%11"])
       "%a,%b=copycreate %acct(%10,%11) send %val"
-  , testInstruction
+  , testIeleInst
       "SelfDestruct"
       (VoidOp SELFDESTRUCT ["%10"])
       "selfdestruct %10"
@@ -336,7 +334,7 @@ instructionTests =
 
 otherTests :: [TestTree]
 otherTests =
-  let dummy = LiOp LOADPOS "%0" 0 in
+  let dummy = IeleInst (LiOp LOADPOS "%0" 0) in
   [ testCase
       "empty LabelledBlock"
       (parseSuccess
@@ -421,12 +419,18 @@ otherTests =
         "define@a(){b:%0=0}"
       )
   , testCase
-      "global variable TopLevelDefinition"
+      "external contract declaration"
       (parseSuccess
         (TopLevelDefinitionContract "a")
         topLevelDefinition
-        "contract a"
+        "external contract a"
       )
+  , testCase
+      "global definition"
+      (parseSuccess
+        (TopLevelDefinitionGlobal "@a" 12)
+        topLevelDefinition
+        "@a = 12")
   , testCase
       "TopLevelDefinitions"
       (parseSuccess
@@ -436,9 +440,10 @@ otherTests =
             [ LabeledBlock "b" [dummy,dummy]
             , LabeledBlock "c" [dummy]])
          , TopLevelDefinitionContract "a"
+         , TopLevelDefinitionGlobal "@b" 10
          ]
         (many topLevelDefinition)
-        "define@a(){%0=0 %0=0 b:%0=0 %0=0 c:%0=0}contract a"
+        "define@a(){%0=0 %0=0 b:%0=0 %0=0 c:%0=0}external contract a @b=10"
       )
   ]
 
@@ -451,36 +456,36 @@ parseSuccess expected parser input =
   assertEqual
     "Expecting parse success!"
     (Right expected)
-    (parse parser "" input)
+    (parse (parser <* eof) "" input)
 
 parseFailure :: (Show a, Eq a) => Parser a -> String -> Assertion
 parseFailure parser input =
-  assertBool "Expecting parse failure!" (isLeft (parse parser "" input))
+  assertBool "Expecting parse failure!" (isLeft (parse (parser <* eof) "" input))
 
 ------------------------------------
--- Instruction test utilities
+-- IeleOp test utilities
 ------------------------------------
 
 testBinaryOperation :: String -> IeleOpcode1 ->  TestTree
 testBinaryOperation name op =
-  testInstruction
+  testIeleInst
     name
-    (Op op "%a" ["%10","@b"])
-    ("%a=" ++ name ++ " %10,@b")
+    (Op op "%a" ["%10","%b"])
+    ("%a=" ++ name ++ " %10,%b")
 
 testPredicateOperation :: String -> IeleOpcode1 ->  TestTree
 testPredicateOperation name op =
-  testInstruction
+  testIeleInst
     name
-    (Op op "%a" ["%10","@11"])
-    ("%a=cmp " ++ name ++ " %10,@11")
+    (Op op "%a" ["%10","%11"])
+    ("%a=cmp " ++ name ++ " %10,%11")
 
 testTernaryOperation :: String -> IeleOpcode1 ->  TestTree
 testTernaryOperation name op =
-  testInstruction
+  testIeleInst
     name
-    (Op op "%a" ["%10","@11","%12"])
-    ("%a=" ++ name ++ " %10,@11, %12")
+    (Op op "%a" ["%10","%11","%12"])
+    ("%a=" ++ name ++ " %10,%11, %12")
 
 testInstruction :: String -> Instruction -> String -> TestTree
 testInstruction name expected input =
@@ -496,6 +501,9 @@ testInstruction name expected input =
               (input ++ " " ++ input)
           )
       ]
+
+testIeleInst :: String -> IeleOpP -> String -> TestTree
+testIeleInst name expected input = testInstruction name (IeleInst expected) input
 
 ------------------------------------
 -- Token test utilities

--- a/compiler/test/TestParser.hs
+++ b/compiler/test/TestParser.hs
@@ -281,20 +281,16 @@ instructionTests =
         "call@c at %acct(%10,%11)send %amt, gaslimit %gas")
   , testIeleInst
       "Return"
-      (VoidOp (RETURN (mkRets 2)) ["%10","%11"])
+      (VoidOp (RETURN (mkArgs 2)) ["%10","%11"])
       "ret %10, %11"
   , testIeleInst
       "empty Return"
-      (VoidOp (RETURN (mkRets 0)) [])
+      (VoidOp (RETURN (mkArgs 0)) [])
       "ret void"
   , testIeleInst
       "Revert"
-      (VoidOp (REVERT (mkRets 2)) ["%10","%11"])
-      "revert %10, %11"
-  , testIeleInst
-      "empty Revert"
-      (VoidOp (REVERT (mkRets 0)) [])
-      "revert void"
+      (VoidOp (REVERT (mkArgs 1)) ["%10"])
+      "revert %10"
   , testIeleInst
       "Log 0"
       (VoidOp (LOG 0) ["%idx"])


### PR DESCRIPTION
Update assembler so globals are just named constants, so create and copycreate return separate results for status and new address, and to correctly assemble external contract declarations.