### PR TITLE
Support global definitions, immediates, output options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@
 /.build/rvk/*
 
 !/.build/secp256k1
-!/.build/pandoc-tangle
+!/.build/pyethereum
 
 /tests/proofs
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule ".build/secp256k1"]
 	path = .build/secp256k1
 	url = https://github.com/bitcoin-core/secp256k1
+[submodule ".build/pyethereum"]
+	path = .build/pyethereum
+	url = https://github.com/ethereum/pyethereum

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,10 +6,11 @@ In a nutshell, to install IELE on an Ubuntu 16.04 machine, run:
 ```
 
 sudo apt-get update
-sudo apt-get install make gcc maven openjdk-8-jdk flex opam pkg-config libmpfr-dev autoconf libtool pandoc
+sudo apt-get install make gcc maven openjdk-8-jdk flex opam pkg-config libmpfr-dev autoconf libtool pandoc libssl-devl build-essential libffi-dev
 git submodule update --init # Initialize submodules
 curl -sSL https://get.haskellstack.org/ | sh # Install stack
 cd .build/secp256k1 && ./autogen.sh && ./configure --enable-module-recovery && make && sudo make install # install secp256k1 from bitcoin-core
+cd .build/pyethereum && sudo python setup.py install # install pyethereum to sign "ethereum" transactions
 make deps # Build dependencies not installed by package manager
 eval `opam config env` # add OCAML installation to path
 make # Build project

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,7 +9,7 @@ sudo apt-get update
 sudo apt-get install make gcc maven openjdk-8-jdk flex opam pkg-config libmpfr-dev autoconf libtool pandoc libssl-devl build-essential libffi-dev
 git submodule update --init # Initialize submodules
 curl -sSL https://get.haskellstack.org/ | sh # Install stack
-cd .build/secp256k1 && ./autogen.sh && ./configure --enable-module-recovery && make && sudo make install # install secp256k1 from bitcoin-core
+cd .build/secp256k1 && ./autogen.sh && ./configure --enable-module-recovery --enable-module-ecdh --enable-experimental && make && sudo make install # install secp256k1 from bitcoin-core
 cd .build/pyethereum && sudo python setup.py install # install pyethereum to sign "ethereum" transactions
 make deps # Build dependencies not installed by package manager
 eval `opam config env` # add OCAML installation to path

--- a/compiler/README.md
+++ b/compiler/README.md
@@ -1,7 +1,8 @@
 # compiler
 To build: `stack build`.
-all dependencies are managed by stack
+all dependencies are managed by stack.
 
-To run: `stack exec iele-assmble`.
+To run: `stack exec iele-assemble FILE`.
+or `stack exec iele-assemble -- [OPTIONS] FILE`.
 
 To run the tests: `stack test`

--- a/compiler/README.md
+++ b/compiler/README.md
@@ -1,6 +1,7 @@
 # compiler
 To build: `stack build`.
+all dependencies are managed by stack
 
-To run: `stack exec compiler-exe`.
+To run: `stack exec iele-assmble`.
 
 To run the tests: `stack test`

--- a/compiler/app/Main.hs
+++ b/compiler/app/Main.hs
@@ -93,6 +93,22 @@ main :: IO ()
 main = do
   args <- getArgs
   case args of
+    ["--parse",file] -> do
+      contents <- readFile file
+      case parse ieleParser file contents of
+        Left err  -> do
+          hPrint stderr err
+          exitWith (ExitFailure 1)
+        Right cs  -> do
+          putStr (show (prettyContractsP cs))
+    ["--desugar",file] -> do
+      contents <- readFile file
+      case parse ieleParser file contents of
+        Left err  -> do
+          hPrint stderr err
+          exitWith (ExitFailure 1)
+        Right cs  -> do
+          putStr (show (prettyContractsD (map processContract cs)))
     [file] -> do
       contents <- readFile file
       case parse ieleParser file contents of
@@ -107,6 +123,6 @@ main = do
           writeFile "test2.iele" (show (prettyContract c'))
            -}
           B.putStr . b16Enc . assemble . compileContracts $ cs
-    _ -> putStrLn "Usage: iele-assemble FILE"
+    _ -> putStrLn "Usage: iele-assemble [--parse | --desugar] FILE"
 
 --parse anyChar "" "a"

--- a/compiler/compiler.cabal
+++ b/compiler/compiler.cabal
@@ -22,6 +22,7 @@ library
                      , IeleInstructions
                      , IeleAssembler
                      , IeleParserImplementation
+  other-modules:       IeleTHUtil
   build-depends:       base >= 4.7 && < 5
                      , parsec >=3.1 && <3.2
                      , containers
@@ -32,6 +33,7 @@ library
                      , bytestring
                      , pretty
                      , sandi
+                     , template-haskell
   default-language:    Haskell2010
 
 executable iele-assemble

--- a/compiler/src/IeleDesugar.hs
+++ b/compiler/src/IeleDesugar.hs
@@ -18,9 +18,37 @@ import Data.Data.Lens
 import IeleInstructions
 import IeleAssembler
 import IeleTypes
-import IelePrint(prettyInst)
+import IelePrint(prettyInst,prettyName)
 
 type IeleNameNum = Int
+
+lookupGlobal :: Map GlobalName Integer
+             -> Operand
+             -> Either Integer LValue
+lookupGlobal definitions op = case op of
+  RegOperand r -> Right r
+  ImmOperand (IntToken i) -> Left i
+  GlobalOperand g
+    | Just val <- Map.lookup g definitions -> Left val
+    | otherwise -> error $ "Undefined global "++show (prettyName g)++" in operand"
+
+expandImmediates :: IeleOpG con fun lbl LValue (Either Integer LValue)
+                 -> [IeleOpG con fun lbl LValue LValue]
+expandImmediates (Op MOVE tgt [Left imm]) = [loadImm tgt imm]
+expandImmediates inst =
+  let processArg (loads,nextTmp) (Left imm) =
+         let tmpReg = LValueLocalName (LocalName (IeleNameText ("iele.tmp"++show nextTmp)))
+         in (((loadImm tmpReg imm:loads),1+nextTmp),tmpReg)
+      processArg acc (Right reg) = (acc,reg)
+      ((loads,_),inst') = mapAccumLOf ieleOpArg processArg ([],0) inst
+  in reverse loads++[inst']
+
+desugarFundef :: Map GlobalName Integer
+              -> FunctionDefinitionP
+              -> FunctionDefinitionD IeleName GlobalName IeleName LValue
+desugarFundef globals fundef =
+  fundef & functionInsts %~ concatMap expandImmediates
+                          . (traverse . ieleOpArg %~ lookupGlobal globals)
 
 {- | Assigns numbers to the given set, avoiding the already-used numbers -}
 assignNumbers :: (Ord a) => IntSet -> [a] -> Map a Int
@@ -41,16 +69,17 @@ numberIeleNames names =
   assignNumbers (IntSet.fromList [x | IeleNameNumber x <- names])
                 [s | IeleNameText s <- names]
 
-applyIeleNameMap :: Map String Int -> IeleName -> IeleName
-applyIeleNameMap _ n@(IeleNameNumber _) = n
+applyIeleNameMap :: Map String Int -> IeleName -> Int
+applyIeleNameMap _ (IeleNameNumber n) = n
 applyIeleNameMap mapping (IeleNameText t)
-  | Just ix <- Map.lookup t mapping = IeleNameNumber ix
+  | Just ix <- Map.lookup t mapping = ix
 
-numberBlocks :: FunctionDefinition -> FunctionDefinition
+numberBlocks :: FunctionDefinitionD conId funId IeleName reg
+             -> FunctionDefinitionD conId funId Word16 reg
 numberBlocks funDef =
-  let rename = applyIeleNameMap (numberIeleNames (funDef ^.. blocks . traverse . label))
+  let rename = fromIntegral . applyIeleNameMap (numberIeleNames (funDef ^.. blocks . traverse . label))
   in funDef & blocks . traverse . label %~ rename
-            & functionInsts . instructionJumpDest %~ rename
+            & functionInsts . traverse . ieleOpJumpDest %~ rename
 
 assignLocals :: [IeleName] -> [IeleName] -> Map String Int
 assignLocals args bodyRefs =
@@ -59,130 +88,78 @@ assignLocals args bodyRefs =
       namedArgs = [(t,ix) | (IeleNameText t,ix) <- zip args [0..]]
   in extendAssignment (Map.fromList namedArgs) usedNums usedNames
 
-numberLocals :: FunctionDefinition -> FunctionDefinition
+numberLocals :: FunctionDefinitionD conId funId blkId LValue
+             -> FunctionDefinitionD conId funId blkId Int
 numberLocals funDef =
-  let funLocalRegs, funParams :: Traversal' FunctionDefinition IeleName
-      funLocalRegs = template . instructionRegisters . _LValueLocalName . _LocalName
-      funParams = parameters . traverse . _LocalName
-      rename = applyIeleNameMap (assignLocals (funDef ^.. funParams)
-                                              (funDef ^.. funLocalRegs))
-  in funDef & funParams %~ rename
+  let funLocalRegs f = (functionInsts . traverse . ieleOpRegs') f
+      funParams f = (parameters . traverse) f
+      assignment = assignLocals (funDef ^.. funParams . _LValueLocalName . _LocalName)
+                                (funDef ^.. funLocalRegs . _LValueLocalName . _LocalName)
+      rename (LValueLocalName (LocalName name)) = applyIeleNameMap assignment name
+  in funDef & parameters . traverse  %~ rename
             & funLocalRegs %~ rename
 
-expandGlobals :: Contract -> Contract
-expandGlobals contract =
-  let globalVals = Map.fromList [(g,val) | TopLevelDefinitionGlobal g val <-
-                                    contractDefinitions contract]
-      definitions = [d | d <- contractDefinitions contract,
-                         case d of {TopLevelDefinitionGlobal _ _ -> False; _ -> True}]
-      desugarLoadGlobal :: Instruction -> Instruction
-      desugarLoadGlobal i@(SugarInst (LoadGlobal dest g))
-        | Just v <- Map.lookup g globalVals =
-            if v >= 0
-            then IeleInst (LiOp LOADPOS dest v)
-            else IeleInst (LiOp LOADNEG dest (abs v))
-        | otherwise = error $ "attempting to load unknown global in "++show (prettyInst i)
-      desugarLoadGlobal i = i
-  in contract {contractDefinitions = definitions}
-        & template %~ desugarLoadGlobal
+setNub :: (Ord a) => [a] -> [a]
+setNub l = go Set.empty l
+  where go _ [] = []
+        go acc (x:xs) = if Set.member x acc
+                        then go acc xs
+                        else x:go (Set.insert x acc) xs
 
-functionDefinitions :: Traversal' Contract FunctionDefinition
-functionDefinitions = template
+numberDecls :: [IeleName]
+            -> [FunctionDefinitionD IeleName GlobalName blk reg]
+            -> ([String],[FunctionDefinitionD Word16 Word16 blk reg])
+numberDecls declaredContracts fundefs =
+  let declaredFuns = fundefs ^.. traverse . name . _GlobalName
+      calledFuns = fundefs ^.. traverse . functionInsts . traverse . ieleOpFunId . _GlobalName
+      functionNames = setNub (IeleNameText "init":declaredFuns++calledFuns)
+      nextId = length functionNames
+      functionMapping = Map.fromList (zip functionNames [fromIntegral 0..])
+      contractMapping = Map.fromList (zip declaredContracts [fromIntegral nextId..])
+      renameFunction (GlobalName g) = functionMapping Map.! g
+      renameContract c = contractMapping Map.! c
+  in ([n | IeleNameText n <- tail functionNames],
+      fundefs & traverse . name %~ renameFunction
+              & traverse . functionInsts . traverse . ieleOpFunId %~ renameFunction
+              & traverse . functionInsts . traverse . ieleOpContract %~ renameContract)
 
-calledFunctions :: Traversal' Contract IeleName
-calledFunctions = template . instructionCallName . _GlobalName
+processContract :: ContractP -> (IeleName, ContractD IeleName)
+processContract (ContractP name _ definitions) =
+  let externalContracts = [con | TopLevelDefinitionContract con <- definitions]
+      globalDefs = Map.fromList [(g,v) | TopLevelDefinitionGlobal g v <- definitions]
+      funDefs = [f | TopLevelDefinitionFunction f <- definitions]
+      funDefs' :: [FunctionDefinitionD IeleName GlobalName Word16 Int]
+      funDefs' = map (numberLocals . numberBlocks . desugarFundef globalDefs) funDefs
+      (functionNames,funDefsD) = numberDecls externalContracts funDefs'
+  in (name, ContractD functionNames externalContracts funDefsD)
 
-declaredFunctions :: Traversal' Contract IeleName
-declaredFunctions = functionDefinitions . name . _GlobalName
-
-createdContracts :: Traversal' Contract IeleName
-createdContracts = template . instructionContractName
-
-numberDecls :: Contract -> ([IeleName],[IeleName],[FunctionDefinition])
-numberDecls contract = let
-  funNames = contract ^.. declaredFunctions ++ contract ^.. calledFunctions
-  funDecls = Set.delete (IeleNameText "init") (Set.fromList funNames)
-  contractDecls = [name | TopLevelDefinitionContract name <- contractDefinitions contract]
-  functionTable = Set.toList funDecls
-  functionMapping = Map.insert (IeleNameText "init") (IeleNameNumber 0)
-      (Map.fromList (zip functionTable (map IeleNameNumber [1..])))
-  contractNums = map IeleNameNumber [1 + length functionTable..]
-  contractMapping = Map.fromList (zip contractDecls contractNums)
- in (functionTable,
-     contractDecls,
-     toListOf functionDefinitions $
-      contract & calledFunctions %~ (functionMapping !)
-               & declaredFunctions %~ (functionMapping !)
-               & createdContracts %~ (contractMapping !))
-
-processContract :: Contract -> ([IeleName],[IeleName],[FunctionDefinition])
-processContract contract =
-  let (funDecls,contractDecls,funDefs) = numberDecls (expandGlobals contract)
-      numberedFuns = map (numberLocals . numberBlocks) funDefs
-  in  (funDecls,contractDecls,numberedFuns)
-
-type IeleOp' = IeleOpG Word16 Word16 Word16 LValue
-
-flattenFundef :: FunctionDefinition -> [IeleOp']
+flattenFundef :: FunctionDefinitionD Word16 Word16 Word16 Int -> [IeleOp]
 flattenFundef (FunctionDefinition isPublic name args entry blocks) =
-  let GlobalName (IeleNameNumber funNum) = name
-      funNum16 = fromIntegral funNum
-  in [VoidOp ((if isPublic then EXTCALLDEST else CALLDEST) funNum16 (argsLength args)) []]
-  ++ flattenInsts entry
-  ++ concatMap flattenBlock blocks
+  VoidOp ((if isPublic then EXTCALLDEST else CALLDEST) name (argsLength args)) []
+  :entry++concatMap flattenBlock blocks
 
-flattenBlock :: LabeledBlock -> [IeleOp']
-flattenBlock (LabeledBlock (IeleNameNumber lbl) insts) =
-  [VoidOp (JUMPDEST (fromIntegral lbl)) []]
-  ++ flattenInsts insts
-
-flattenInsts :: [Instruction] -> [IeleOp']
-flattenInsts = map flattenInst
-
-flattenInst :: Instruction -> IeleOp'
-flattenInst (IeleInst i) = flattenIeleInst i
-flattenInst (SugarInst s) = error "sugar-only instructions should have been expanded by now"
-
-flattenIeleInst :: IeleOpP -> IeleOp'
-flattenIeleInst Nop = Nop
-flattenIeleInst (Op op1 result args) = Op op1 result args
-flattenIeleInst (VoidOp op0 args) =
-  VoidOp (bimap flattenGlobalName flattenName op0) args
-flattenIeleInst (CallOp callOp results args) =
-  CallOp (bimap flattenName flattenGlobalName callOp) results args
-flattenIeleInst (LiOp op result val) = LiOp op result val
-
-flattenName :: IeleName -> Word16
-flattenName (IeleNameNumber i) = fromIntegral i
-flattenName (IeleNameText t) = error $ "residual text name "++t
-
-flattenGlobalName :: GlobalName -> Word16
-flattenGlobalName (GlobalName i) = flattenName i
+flattenBlock :: LabeledBlock Word16 IeleOp  -> [IeleOp]
+flattenBlock (LabeledBlock lbl insts) =
+  VoidOp (JUMPDEST lbl) []:insts
 
 neededBits :: Integral a => a -> Int
 neededBits max = ceiling (logBase 2 (fromIntegral max+1))
 
-countRegisters :: [IeleOp'] -> [IeleOp]
-countRegisters ops' =
-  let maxRegs = maximumOf (traverse . traverse . to regNum) ops'
-      nbits = case maxRegs of
-        Nothing -> 0
-        Just maxNum -> neededBits maxNum
-      regNum (LValueLocalName (LocalName (IeleNameNumber i))) = i
-      regNum l = error $ "Residual textual name "++show l
-      valToInt (LValueLocalName (LocalName (IeleNameNumber i))) = i
-  in [VoidOp (REGISTERS (fromIntegral nbits)) []]
-     ++ over (traverse . traverse) valToInt ops'
+addRegisterCount insts =
+  let nbits = case maximumOf (traverse . ieleOpRegs') insts of
+            Nothing -> 0
+            Just maxReg -> neededBits maxReg
+  in VoidOp (REGISTERS (fromIntegral nbits)) []:insts
 
-compileContract :: Map IeleName B.ByteString -> Contract -> [IeleOp]
+compileContract :: Map IeleName B.ByteString -> ContractP -> [IeleOp]
 compileContract childContracts contract =
-  let (functions,contracts,fundefs) = processContract contract
-      ops' = [VoidOp (FUNCTION t) [] | IeleNameText t <- functions]
-             ++ [VoidOp (CONTRACT (childContracts ! c)) [] | c <- contracts]
-             ++ concatMap flattenFundef fundefs
-  in countRegisters ops'
+  let (_, ContractD funNames externalContracts funDefs) = processContract contract
+      ops' = [VoidOp (FUNCTION t) [] | t <- funNames]
+             ++ [VoidOp (CONTRACT (childContracts ! c)) [] | c <- externalContracts]
+             ++ concatMap flattenFundef funDefs
+  in addRegisterCount ops'
 
-compileContracts :: [Contract] -> [IeleOp]
+compileContracts :: [ContractP] -> [IeleOp]
 compileContracts [] = []
 compileContracts (c:cs) = go Map.empty c cs
   where go childContracts main [] = compileContract childContracts main

--- a/compiler/src/IelePrint.hs
+++ b/compiler/src/IelePrint.hs
@@ -1,13 +1,29 @@
-module IelePrint (prettyContracts, prettyContract, prettyInst) where
+module IelePrint
+  ( prettyContractsP
+  , prettyContractP
+  , prettyInst
+  , prettyContractD
+  , prettyContractsD
+  , PrettyNames(prettyName)
+  ) where
 import Prelude hiding (LT,EQ,GT)
 
 import Text.PrettyPrint
 import Data.List(intersperse)
+import Data.Word(Word16)
+
+import Control.Lens
+
+import Codec.Binary.Base16(b16Enc)
 
 import IeleInstructions
 import IeleTypes
 
-prettyContracts contracts = vcat (map prettyContract contracts) $+$ text ""
+prettyContractsP :: [ContractP] -> Doc
+prettyContractsP contracts = vcat (map prettyContractP contracts) $+$ text ""
+
+prettyContractsD :: [(IeleName,ContractD IeleName)] -> Doc
+prettyContractsD contracts = vcat (map prettyContractD contracts) $+$ text ""
 
 class PrettyNames n where
   prettyName :: n -> Doc
@@ -18,31 +34,70 @@ instance PrettyNames LocalName where
   prettyName (LocalName n) = char '%' <> prettyName n
 instance PrettyNames GlobalName where
   prettyName (GlobalName n) = char '@' <> prettyName n
+instance PrettyNames LValue where
+  prettyName (LValueLocalName l) = prettyName l
 
 braceGroup :: Doc -> [Doc] -> Doc
 braceGroup head body = head <+> char '{' $$ nest 2 (vcat body) $$ char '}'
 
 braceGroupFlat :: Doc -> [Doc] -> Doc
-braceGroupFlat head body = head <+> char '{' $$ vcat (intersperse blank body) $$ char '}'
+braceGroupFlat head body = head <+> char '{' $$ vcat body $$ char '}'
 
 blank :: Doc
 blank = text ""
 
-prettyContract :: Contract -> Doc
-prettyContract (Contract name size defs) =
-  braceGroupFlat (text "contract" <+> prettyName name
-                  <+> maybe empty (\sz -> char '!' <> int sz) size)
+prettyContractP :: ContractP -> Doc
+prettyContractP (ContractP name size defs) =
+  braceGroup (text "contract" <+> prettyName name
+                <+> maybe empty (\sz -> char '!' <> int sz) size)
     (empty:map prettyDef defs++[empty])
 
-prettyDef :: TopLevelDefinition -> Doc
-prettyDef (TopLevelDefinitionFunction funDef) = prettyFunDef funDef
--- prettyDef (TopLevelDefinitionContract conRef) = prettyConRef conRef
+prettyContractD :: (IeleName,ContractD IeleName) -> Doc
+prettyContractD (cname, ContractD functionNames externalContracts functionDefinitions) =
+  braceGroup (text "contract" <+> prettyName cname) $
+    (if null functionNames then []
+     else [vcat [text "!function "<+> text (show f) | f <- functionNames]
+          ,blank])
+  ++(if null externalContracts then []
+     else [vcat [text "external contract"<+>prettyName c | c <- externalContracts]
+          ,blank])
+  ++intersperse blank (map (prettyFunDef . formatDef) functionDefinitions)
+ where
+  numToLValue n = LValueLocalName (LocalName (IeleNameNumber n))
+  formatDef :: FunctionDefinitionD Word16 Word16 Word16 Int
+            -> FunctionDefinition GlobalName IeleName LValue Doc
+  formatDef def = def & name %~ GlobalName . IeleNameNumber . fromIntegral
+                      & parameters . traverse %~ numToLValue
+                      & blocks . traverse . label %~ IeleNameNumber . fromIntegral
+                      & functionInsts . traverse %~ prettyOp
+  formatOp :: IeleOp -> IeleOpG IeleName GlobalName IeleName LValue Doc
+  formatOp op = runIdentity $ retypeIeleOp
+    (pure . IeleNameNumber . fromIntegral )
+    (pure . GlobalName . IeleNameNumber . fromIntegral)
+    (pure . IeleNameNumber . fromIntegral)
+    (pure . LValueLocalName . LocalName . IeleNameNumber . fromIntegral)
+    (pure . prettyName . LValueLocalName . LocalName . IeleNameNumber)
+    op
 
+  prettyOp :: IeleOp -> Doc
+  prettyOp op = prettyIeleInst (formatOp op)
+
+prettyDef :: TopLevelDefinition -> Doc
+prettyDef (TopLevelDefinitionFunction funDef) = prettyFunDef
+  (funDef & functionInsts . traverse %~ prettyInst)
+prettyDef (TopLevelDefinitionContract conRef) =
+  text "external" <+> text "contract" <+> prettyName conRef
+prettyDef (TopLevelDefinitionGlobal g val) =
+  prettyName g <+> char '=' <+> integer val
+
+prettyFunDef :: (PrettyNames contractId, PrettyNames funId)
+             => FunctionDefinition contractId funId LValue Doc -> Doc
 prettyFunDef (FunctionDefinition public name args entry blocks) =
   braceGroupFlat
     (text "define" <+> (if public then text "public" else empty)
       <+> prettyName name <> char '(' <> commaList (map prettyName args) <> char ')')
-    (nest 4 (vcat (map prettyInst entry))
+
+    (nest 2 (vcat entry)
     :map prettyBlock blocks)
 
 commaList :: [Doc] -> Doc
@@ -50,76 +105,149 @@ commaList docs = hsep (punctuate comma docs)
 
 prettyBlock (LabeledBlock name insts) =
   prettyName name <> char ':' $+$
-  nest 4 (vcat (map prettyInst insts))
+  nest 2 (vcat insts)
 
 prettyInst :: Instruction -> Doc
-prettyInst (IeleInst i) = prettyIeleInst i
-prettyInst (SugarInst s) = prettySugarInst s
+prettyInst i = prettyIeleInst (over ieleOpArg prettyOperand i)
 
-prettySugarInst (LoadGlobal tgt g) =
-  prettyVal tgt <+> char '=' <+> prettyName g
+prettyOperand (RegOperand (LValueLocalName l)) = prettyName l
+prettyOperand (GlobalOperand g) = prettyName g
+prettyOperand (ImmOperand (IntToken i)) = integer i
 
-prettyIeleInst :: IeleOpP -> Doc
-prettyIeleInst (Op MOVE tgt [src]) = inst [tgt] empty [prettyVal src]
-prettyIeleInst (Op (IeleOpcodesQuery q) tgt []) =
-  prettyVal tgt <+> char '=' <+> text "call" <+> text (queryName q) <> text "()"
-prettyIeleInst (Op op tgt [a]) = instVals [tgt] (op1Name op) [a]
-prettyIeleInst (Op op tgt [a,b]) = instVals [tgt] (op2Name op) [a,b]
-prettyIeleInst (VoidOp (JUMP lbl) []) = prettyJump lbl
-prettyIeleInst (VoidOp (JUMPI lbl) [reg]) = prettyCondJump reg lbl
-prettyIeleInst (VoidOp (RETURN _) args) = prettyReturn args
-prettyIeleInst (VoidOp INVALID []) = text "call @iele.invalid()"
-prettyIeleInst (VoidOp SSTORE [val,tgt]) = instVals [] "sstore" [val,tgt]
-prettyIeleInst (VoidOp MSTORE [val,tgt]) = instVals [] "mstore" [val,tgt]
-prettyIeleInst (VoidOp (LOG _) args) = instVals [] "log" args
+type IeleOpPretty = IeleOpG IeleName GlobalName IeleName LValue Doc
+prettyIeleInst Nop = text "nop"
+prettyIeleInst (Op op1 tgt args) = prettyName tgt <+> char '=' <+> prettyOp1 op1 args
+prettyIeleInst (VoidOp op args) = prettyVoidOp op args
 prettyIeleInst (LiOp LOADPOS tgt i) = inst [tgt] empty [integer i]
 prettyIeleInst (LiOp LOADNEG tgt i) = inst [tgt] empty [integer (negate i)]
 prettyIeleInst (CallOp (LOCALCALL name _ _) results args) =
   prettyResults results <+> text "call" <+> prettyName name
-    <> char '(' <> commaList (map prettyVal args) <> char ')'
-prettyIeleInst (CallOp (CALL name _ _) results (gas:acct:val:args)) =
-  prettyResults results <+> text "call" <+> prettyName name
-    <+> text "at" <+> prettyVal acct
-    <> char '(' <> commaList (map prettyVal args) <> char ')'
-    <+> text "send" <+> prettyVal val <> comma <+> text "gaslimit" <+> prettyVal gas
-prettyIeleInst (CallOp (STATICCALL name _ _) results (gas:acct:val:args)) =
-  prettyResults results <+> text "staticcall" <+> prettyName name
-    <+> text "at" <+> prettyVal acct
-    <> char '(' <> commaList (map prettyVal args) <> char ')'
-    <+> text "send" <+> prettyVal val <> comma <+> text "gaslimit" <+> prettyVal gas
+    <> char '(' <> commaList args <> char ')'
+prettyIeleInst (CallOp (CALL name _ _) results allArgs) = case results of
+  [] -> error "external call instruction must have at least one result"
+  _ -> case allArgs of
+         (gas:acct:val:args) ->
+           prettyResults results <+> text "call" <+> prettyName name
+             <+> text "at" <+> acct
+             <> char '(' <> commaList args <> char ')'
+             <+> text "send" <+> val <> comma <+> text "gaslimit" <+> gas
+         _ -> error "external call instruction must encode at least target, gaslimit, and value arguments"
+prettyIeleInst (CallOp (STATICCALL name _ _) results allArgs) = case results of
+  [] -> error "external call instruction must have at least one result"
+  _ -> case allArgs of
+         (gas:acct:val:args) ->
+           prettyResults results <+> text "staticcall" <+> prettyName name
+             <+> text "at" <+> acct
+             <> char '(' <> commaList args <> char ')'
+             <+> text "send" <+> val <> comma <+> text "gaslimit" <+> gas
+         _ -> error "external staticcall instruction must encode at least target, gaslimit, and value arguments"
+prettyIeleInst (CallOp (CREATE name _) results (val:args)) = case results of
+  [status,addr] ->
+    prettyResults [status,addr] <+> text "create"
+      <+> prettyName name <> char '(' <> commaList args <> char ')' <+> text "send" <+> val
+  _ -> error "create instruction returns exactly two results"
+prettyIeleInst (CallOp (CREATE _ _) _ _) =
+  error "create instruction must encode at least one argument, for passed value"
+prettyIeleInst (CallOp (COPYCREATE _) results (val:from:args)) = case results of
+  [status,addr] ->
+    prettyResults [status,addr] <+> text "create"
+      <+> from <> char '(' <> commaList args <> char ')' <+> text "send" <+> val
+  _ -> error "copycreate instruction returns exactly two results"
+prettyIeleInst (CallOp (COPYCREATE _) _ _) =
+  error "copycreate instruction must encode at least two arguments, for source account and passed value"
 
-prettyIeleInst o = text ('#':show o)
 
-queryName CALLER = "@iele.caller"
-queryName q = '#':show q
+-- prettyIeleInst o = text ('#':show o)
 
-op1Name o = case o of
-  SLOAD -> "sload"
-  _ -> '#':show o
+prettyOp1 :: IeleOpcode1 -> [Doc] -> Doc
+prettyOp1 op args = case op of
+  MOVE -> commaList args
+  IeleOpcodesQuery q ->
+    text "call" <+> text (queryName q) <> char '(' <> commaList args <> char ')'
+  ADD -> simple "add"
+  MUL -> simple "mul"
+  SUB -> simple "sub"
+  DIV -> simple "div"
+  MOD -> simple "mod"
+  EXP -> simple "exp"
+  ADDMOD -> simple "addmod"
+  MULMOD -> simple "mulmod"
+  EXPMOD -> simple "expmod"
+  SIGNEXTEND -> simple "sext"
+  TWOS -> simple "twos"
+  NE -> simple "cmp ne"
+  LT -> simple "cmp lt"
+  GT -> simple "cmp gt"
+  LE -> simple "cmp le"
+  GE -> simple "cmp ge"
+  EQ -> simple "cmp eq"
+  ISZERO -> simple "iszero"
+  AND -> simple "and"
+  OR -> simple "or"
+  XOR -> simple "xor"
+  NOT -> simple "not"
+  BYTE -> simple "byte"
+  SHA3 -> simple "sha3"
+  MLOADN -> simple "load"
+  MLOAD -> simple "load"
+  SLOAD -> simple "sload"
+ where
+  simple name = text name <+> commaList args
 
-op2Name o = case o of
-  NE -> "cmp ne"
-  LT -> "cmp lt"
-  GT -> "cmp gt"
-  LE -> "cmp le"
-  GE -> "cmp ge"
-  EQ -> "cmp eq"
+queryName q = case q of
+  CALLER -> "@iele.caller"
+  TIMESTAMP -> "@iele.timestamp"
+  CALLVALUE -> "@iele.callvalue"
+  ADDRESS -> "@iele.address"
+  BALANCE -> "@iele.balance"
+  ORIGIN -> "@iele.origin"
+  CODESIZE -> "@iele.codesize"
+  GASPRICE -> "@iele.gasprice"
+  EXTCODESIZE -> "@iele.extcodesize"
+  BLOCKHASH -> "@iele.blockhash"
+  BENEFICIARY -> "@iele.beneficiary"
+  NUMBER -> "@iele.number"
+  DIFFICULTY -> "@iele.difficulty"
+  GASLIMIT -> "@iele.gaslimit"
+  MSIZE -> "@iele.msize"
+  GAS -> "@iele.gas"
 
-  ADD -> "add"
-  SUB -> "sub"
-  MUL -> "mul"
-
-  AND -> "and"
-  OR -> "or"
-
-  _ -> '#':show o
+prettyVoidOp op args = case op of
+  JUMP lbl -> case args of
+    [] -> prettyJump lbl
+    _ -> error "unconditional jump takes no register arguments"
+  JUMPI lbl -> case args of
+    [reg] -> prettyCondJump reg lbl
+    _ -> error "conditional jump takes exactly one register argument"
+  RETURN _ -> prettyReturn args
+  REVERT _ -> case args of
+    [arg] -> text "revert" <+> arg
+    _ -> error "revert takes exactly one argument"
+  INVALID -> text "call @iele.invalid(" <> commaList args <> char ')'
+  SSTORE -> simple "sstore"
+  MSTORE -> simple "store"
+  MSTOREN -> simple "store"
+  (REGISTERS n) -> text "!registers" <+> int (fromIntegral n)
+  (JUMPDEST lbl) -> prettyName lbl <> char ':'
+  (CALLDEST name arity) ->
+    text "!calldest"<+> prettyName name
+      <> char '(' <> int (fromIntegral (argsCount arity)) <> char ')'
+  (EXTCALLDEST name arity) ->
+    text "!extcalldest"<+> prettyName name
+      <> char '(' <> int (fromIntegral (argsCount arity)) <> char ')'
+  (FUNCTION f) -> text "!function" <+> text (show f)
+  (CONTRACT n) -> text "!contract" <+> text (show (b16Enc n))
+  SELFDESTRUCT -> simple "selfdestruct"
+  LOG _ -> simple "log"
+ where
+  simple name = text name <+> commaList args
 
 prettyVal (LValueLocalName n) = prettyName n
 
 prettyJump :: IeleName -> Doc
 prettyJump dest =        text "br" <+> prettyName dest
-prettyCondJump :: LValue -> IeleName -> Doc
-prettyCondJump op dest = text "br" <+> prettyVal op <> comma <+> prettyName dest
+prettyCondJump :: Doc -> IeleName -> Doc
+prettyCondJump op dest = text "br" <+> op <> comma <+> prettyName dest
 
 prettyReturn [] = text "ret void"
 prettyReturn args = instVals [] "ret" args
@@ -134,5 +262,5 @@ inst :: [LValue] -> Doc -> [Doc] -> Doc
 inst results head args =
   prettyResults results <+> head <+> commaList args
 
-instVals :: [LValue] -> String -> [LValue] -> Doc
-instVals results name vals = inst results (text name) (map prettyVal vals)
+instVals :: [LValue] -> String -> [Doc] -> Doc
+instVals results name vals = inst results (text name) vals

--- a/compiler/src/IeleTHUtil.hs
+++ b/compiler/src/IeleTHUtil.hs
@@ -1,0 +1,24 @@
+module IeleTHUtil where
+import Data.List(stripPrefix)
+import Data.Maybe(maybeToList)
+import Data.Char(isUpper,toLower)
+import Language.Haskell.TH
+import Control.Lens
+import Control.Lens.TH
+
+makeFieldsWithNamer namer tyName =
+  makeLensesWith (defaultFieldRules & lensField .~ namer) tyName
+
+makeFieldsForPrefix :: String -> Name -> DecsQ
+makeFieldsForPrefix prefix tyName = makeFieldsWithNamer namer tyName
+ where
+  namer tyName _ field = maybeToList $ do
+    fieldPart <- stripPrefix prefix (nameBase field)
+    method    <- case fieldPart of
+      (x:xs) | isUpper x -> Just (toLower x:xs)
+      _ -> Nothing
+    let cls = "Has" ++ fieldPart
+    return (MethodName (mkName ("Has"++fieldPart)) (mkName method))
+
+makeFieldsFor :: [(String,String)] -> Name -> DecsQ
+makeFieldsFor mapping tyName = makeFieldsWithNamer (lookingupNamer mapping) tyName

--- a/compiler/src/IeleTypes.hs
+++ b/compiler/src/IeleTypes.hs
@@ -1,65 +1,62 @@
 {-# LANGUAGE TemplateHaskell, MultiParamTypeClasses, FunctionalDependencies, FlexibleInstances, DeriveDataTypeable #-}
 module IeleTypes
-    ( Contract (Contract, contractName, contractSize, contractDefinitions)
+    ( ContractP (ContractP, contractName, contractSize, contractDefinitions)
+    , FunctionDefinitionP
     , FunctionDefinition
       ( FunctionDefinition,
         functionDefinitionPublic, functionDefinitionName,
         functionDefinitionParameters , functionDefinitionBlocks)
+    , name
+    , parameters
+    , blocks
     , IeleName(IeleNameNumber,IeleNameText)
     , IntToken (IntToken)
+    , LabeledBlockP
     , LabeledBlock (LabeledBlock, labeledBlockLabel, labeledBlockInstructions)
+    , label, instructions
     , GlobalName (GlobalName)
     , LocalName (LocalName)
     , LValue (LValueLocalName)
+    , Operand (RegOperand,ImmOperand,GlobalOperand)
     , TopLevelDefinition
       (TopLevelDefinitionContract, TopLevelDefinitionFunction, TopLevelDefinitionGlobal)
 
-    -- type synonyms for parser's instantiations of IeleInstructions' types
-    , Instruction(IeleInst,SugarInst)
-    , SugarInstruction(LoadGlobal)
+    -- type synonyms for parser's instantiations of IeleInstruction's types
+    , Instruction
     , IeleOpP
     , IeleOpcode0P
 
-    , HasName(name)
-    , HasSize(size)
-    , HasDefinitions(definitions)
-
-    , HasPublic(public)
-    , HasBlocks(blocks)
-    , HasParameters(parameters)
-    , HasLabel(label)
-    , HasInstructions(instructions)
     , _LValueLocalName
     , _LocalName
     , _GlobalName
     , _TopLevelDefinitionFunction
-    , instructionRegisters
-    , instructionJumpDest
-    , instructionCallName
-    , instructionContractName
+    , contractBlocks
     , functionInsts
+
+    , FunctionDefinitionD
+    , ContractD
+      ( ContractD, functionNames, externalContracts, functionDefinitions)
     ) where
 import Data.Char
 import Data.String
+import Data.Maybe(maybeToList)
+import Data.List(stripPrefix)
 import Data.Data
+import Data.Word(Word16)
 
 import Control.Lens.TH
+import Language.Haskell.TH hiding (Type)
 import Data.Data.Lens(template)
 import Control.Lens
+import Data.Kind
 
+import IeleTHUtil
 import IeleInstructions
 
-type IeleOpP = IeleOpG IeleName GlobalName IeleName LValue
+type IeleOpP = IeleOpG IeleName GlobalName IeleName LValue Operand
 type IeleOpcode0P = IeleOpcode0G GlobalName IeleName
 
-data Instruction =
-   IeleInst IeleOpP
- | SugarInst SugarInstruction
-  deriving (Show, Eq, Data)
-
-data SugarInstruction =
-  LoadGlobal LValue GlobalName
-  deriving (Show, Eq, Data)
+type Instruction = IeleOpP
 
 data IeleName = IeleNameNumber Int | IeleNameText String
   deriving (Show, Eq, Ord, Data)
@@ -100,57 +97,101 @@ instance IsString LValue where
   fromString str@('%':_) = LValueLocalName (fromString str)
   fromString str = error $ "LValue must begin with % or @ in "++show str
 
-data LabeledBlock = LabeledBlock
-  { labeledBlockLabel :: IeleName
-  , labeledBlockInstructions :: [Instruction]
+data Operand =
+   RegOperand LValue
+ | ImmOperand IntToken
+ | GlobalOperand GlobalName
+  deriving (Show, Eq, Data)
+
+instance IsString Operand where
+  fromString str@('%':_) = RegOperand (fromString str)
+  fromString str@('@':_) = GlobalOperand (fromString str)
+  fromString str
+    | [(imm,"")] <- reads str = ImmOperand (IntToken imm)
+
+type LabeledBlockP = LabeledBlock IeleName Instruction
+data LabeledBlock lblId instruction = LabeledBlock
+  { labeledBlockLabel :: lblId
+  , labeledBlockInstructions :: [instruction]
+  } deriving (Show, Eq, Data)
+label :: Lens
+  (LabeledBlock lbl inst)
+  (LabeledBlock lbl' inst)
+  lbl
+  lbl'
+label f (LabeledBlock label insts) = (\l' -> LabeledBlock l' insts) <$> f label
+instructions :: Lens
+  (LabeledBlock lbl inst)
+  (LabeledBlock lbl inst')
+  [inst]
+  [inst']
+instructions f (LabeledBlock label insts) = LabeledBlock label <$> f insts
+
+type FunctionDefinitionP = FunctionDefinition GlobalName IeleName LValue Instruction
+data FunctionDefinition funId blockId arg instruction = FunctionDefinition
+  { functionDefinitionPublic :: Bool
+  , functionDefinitionName :: funId
+  , functionDefinitionParameters :: [arg]
+  , functionDefinitionEntry :: [instruction]
+  , functionDefinitionBlocks :: [LabeledBlock blockId instruction]
   } deriving (Show, Eq, Data)
 
-data FunctionDefinition = FunctionDefinition
-  { functionDefinitionPublic :: Bool
-  , functionDefinitionName :: GlobalName
-  , functionDefinitionParameters :: [LocalName]
-  , functionDefinitionEntry :: [Instruction]
-  , functionDefinitionBlocks :: [LabeledBlock]
-  } deriving (Show, Eq, Data)
+name :: Lens
+  (FunctionDefinition fun lbl arg inst)
+  (FunctionDefinition fun' lbl arg inst)
+  fun fun'
+name f (FunctionDefinition public name params entry blocks) =
+  (\name' -> FunctionDefinition public name' params entry blocks) <$> f name
+
+parameters :: Lens
+  (FunctionDefinition fun lbl arg inst)
+  (FunctionDefinition fun lbl arg' inst)
+  [arg] [arg']
+parameters f (FunctionDefinition public name params entry blocks) =
+  (\params' -> FunctionDefinition public name params' entry blocks) <$> f params
+
+blocks :: Lens
+  (FunctionDefinition fun lbl arg inst)
+  (FunctionDefinition fun lbl' arg inst)
+  [LabeledBlock lbl inst]
+  [LabeledBlock lbl' inst]
+blocks f (FunctionDefinition public name params entry blocks)
+ = FunctionDefinition public name params entry <$> f blocks
+
 data TopLevelDefinition =
     TopLevelDefinitionContract IeleName
-  | TopLevelDefinitionFunction FunctionDefinition
+  | TopLevelDefinitionFunction FunctionDefinitionP
   | TopLevelDefinitionGlobal GlobalName Integer
   deriving (Show, Eq, Data)
-data Contract = Contract
+data ContractP = ContractP
   { contractName :: IeleName
   , contractSize :: Maybe Int
   , contractDefinitions :: [TopLevelDefinition]
   }
   deriving (Show, Eq, Data)
 
-instructionRegisters :: Traversal' Instruction LValue
-instructionRegisters = template
+type FunctionDefinitionD contract funId blkId reg =
+  FunctionDefinition funId blkId reg (IeleOpG contract funId blkId reg reg)
 
-instructionJumpDest :: Traversal' Instruction IeleName
-instructionJumpDest f (IeleInst (VoidOp (JUMP tgt) []))
-  = fmap (\tgt -> IeleInst (VoidOp (JUMP tgt) [])) (f tgt)
-instructionJumpDest f (IeleInst (VoidOp (JUMPI tgt) [arg]))
-  = fmap (\tgt -> IeleInst (VoidOp (JUMPI tgt) [arg])) (f tgt)
-instructionJumpDest _ i = pure i
+data ContractD contractId = ContractD
+  { functionNames :: [String]
+  , externalContracts :: [contractId]
+  , functionDefinitions :: [FunctionDefinitionD Word16 Word16 Word16 Int]
+  }
 
-instructionCallName :: Traversal' IeleOpP GlobalName
-instructionCallName f (CallOp callOp results args) =
-  (\o' -> CallOp o' results args) <$> traverse f callOp
-instructionCallName _ inst = pure inst
-
-instructionContractName :: Traversal' IeleOpP IeleName
-instructionContractName f (CallOp (CREATE c nargs) results args) =
-  fmap (\c' -> CallOp (CREATE c' nargs) results args) (f c)
-instructionContractName _ inst = pure inst
-
-functionInsts :: Traversal' FunctionDefinition Instruction
-functionInsts = template
-
-makeLensesWith camelCaseFields ''FunctionDefinition
-makeLensesWith camelCaseFields ''LabeledBlock
-makeLensesWith camelCaseFields ''Contract
 makePrisms ''TopLevelDefinition
 makePrisms ''LValue
 makePrisms ''LocalName
 makePrisms ''GlobalName
+
+contractBlocks :: Traversal' ContractP [Instruction]
+contractBlocks = template
+
+functionInsts :: Traversal
+  (FunctionDefinition funId blockId arg inst)
+  (FunctionDefinition funId blockId arg inst')
+  [inst] [inst']
+functionInsts f (FunctionDefinition public name args entry blocks) =
+  FunctionDefinition public name args
+     <$> f entry
+     <*> traverse (instructions f) blocks

--- a/iele-examples/erc20.iele
+++ b/iele-examples/erc20.iele
@@ -1,59 +1,64 @@
 contract ERC20 {
+  @addressShift = 1461501637330902918203684832716283019655932542976 // 2^160
+
+// storage layout
+  // variable location
+  @supplyKey = 0
+  // map prefixes
+  @balanceRegion = 1
+  @allowanceRegion = 2
+
+  // hash of event name
+  @approvalEvent = 51203953783612407010867880206449430888987723574256155352892809266431502985471
+  // hash of event name
+  @transferEvent = 108826829889743193495150187174564778908056497375576552531120215125716493244137
+
 
 // computes a unique index in the account storage for a particular value by partitioning
 // the storage into different regions. %region represents a unique bit prefix on the
 // key that will be ored with the specified address.
 define @mapKey(%region, %address) {
   %addressMask = 20
-  %addressShift = 1461501637330902918203684832716283019655932542976 // 2^160
   %realAddress = twos %addressMask, %address
-  %shifted = mul %addressShift, %region
+  %shifted = mul @addressShift, %region
   %ored = or %shifted, %realAddress
   ret %ored
 }
 
 define @setBalance(%account, %value) {
-  %balanceRegion = 1
-  %key = call @mapKey(%balanceRegion, %account)
+  %key = call @mapKey(@balanceRegion, %account)
   sstore %value, %key
   ret void
 }
 
 define @setAllowance(%owner, %spender, %allowance) {
-  %allowanceRegion = 2
-  %key1 = call @mapKey(%allowanceRegion, %owner)
+  %key1 = call @mapKey(@allowanceRegion, %owner)
   %key2 = call @mapKey(%key1, %spender)
   sstore %allowance, %key2
   ret void
 }
 
 define @log.Approval(%owner, %spender, %allowance) {
-  // hash of event name
-  %approvalEvent = 51203953783612407010867880206449430888987723574256155352892809266431502985471
   %logCell = 0
   store %allowance, %logCell
-  log %logCell, %approvalEvent, %owner, %spender
+  log %logCell, @approvalEvent, %owner, %spender
   ret void
 }
 
 define @log.Transfer(%from, %to, %value) {
-  // hash of event name
-  %transferEvent = 108826829889743193495150187174564778908056497375576552531120215125716493244137
   %logCell = 0
   store %value, %logCell
-  log %logCell, %transferEvent, %from, %to
+  log %logCell, @transferEvent, %from, %to
   ret void
 }
 
 define public @totalSupply() {
-  %supplyKey = 0
-  %supply = sload %supplyKey
+  %supply = sload @supplyKey
   ret %supply
 }
 
 define @init(%supply) {
-  %supplyKey = 0
-  sstore %supply, %supplyKey
+  sstore %supply, @supplyKey
   %caller = call @iele.caller()
   call @setBalance(%caller, %supply)
   ret void
@@ -75,22 +80,18 @@ define public @allowance(%owner, %spender) {
 }
 
 define public @approve(%spender, %allowance) {
-  %zero = 0
-  %retval = 1
-  %lt = cmp lt %allowance, %zero   // this check burns gas :(
+  %lt = cmp lt %allowance, 0   // this check burns gas :(
   br %lt, throw
   %owner = call @iele.caller()  // written as msg.sender in Viper
   call @setAllowance(%owner, %spender, %allowance)
   call @log.Approval(%owner, %spender, %allowance)
-  ret %retval   // should always return true
+  ret true   // should always return true
 throw:
   call @iele.invalid() // throwing exception
 }
 
 define public @transfer(%to, %value) {
-  %zero = 0
-  %retval = 1
-  %lt = cmp lt %value, %zero   // this check burns gas :(
+  %lt = cmp lt %value, 0   // this check burns gas :(
   br %lt, throw
   %from = call @iele.caller()
   %balanceFrom = call @balanceOf(%from)
@@ -102,15 +103,13 @@ define public @transfer(%to, %value) {
   %balanceTo = add %balanceTo, %value  // no worries of overflow
   call @setBalance(%to, %balanceTo)
   call @log.Transfer(%from, %to, %value)
-  ret %retval  // should either return true or throw
+  ret true  // should either return true or throw
 throw:
   call @iele.invalid() // throwing exception
 }
 
 define public @transferFrom(%from, %to, %value) {
-  %zero = 0
-  %retval = 1
-  %lt = cmp lt %value, %zero   // this check burns gas :(
+  %lt = cmp lt %value, 0   // this check burns gas :(
   br %lt, throw
   %caller = call @iele.caller()
   %balanceFrom = call @balanceOf(%from)
@@ -127,7 +126,7 @@ define public @transferFrom(%from, %to, %value) {
   %balanceTo = add %balanceTo, %value  // no worries of overflow
   call @setBalance(%to, %balanceTo)
   call @log.Transfer(%from, %to, %value)
-  ret %retval  // should either return true or throw
+  ret true  // should either return true or throw
 throw:
   call @iele.invalid() // throwing exception
 }


### PR DESCRIPTION
Now allows immediate arguments to any instruction, which
is compiled by loading the immediates into temporary registers.

Allow global definitions of named constants, which expand
into immediate values.

Add options to reprint the input, either immediately after parsing
or just before assembling.