### PR TITLE
Changes to make kast work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,15 +109,15 @@ deps:
 .build/rvk/ethereum-kompiled/extras/timestamp: .build/rvk/ethereum-kompiled/interpreter
 .build/rvk/ethereum-kompiled/interpreter: $(defn_files) KRYPTO.ml
 	@echo "== kompile: $@"
-	${KOMPILE} --debug --main-module ETHEREUM-SIMULATION \
-					--syntax-module ETHEREUM-SIMULATION $< --directory .build/rvk \
+	${KOMPILE} --debug --main-module ETHEREUM \
+					--syntax-module ETHEREUM $< --directory .build/rvk \
 					--hook-namespaces KRYPTO --gen-ml-only -O3 --non-strict
 	ocamlfind opt -c .build/rvk/ethereum-kompiled/constants.ml -package gmp -package zarith
 	ocamlfind opt -c -I .build/rvk/ethereum-kompiled KRYPTO.ml -package cryptokit -package secp256k1 -package bn128
 	ocamlfind opt -a -o semantics.cmxa KRYPTO.cmx
 	ocamlfind remove iele-semantics-plugin
 	ocamlfind install iele-semantics-plugin META semantics.cmxa semantics.a KRYPTO.cmi KRYPTO.cmx
-	${KOMPILE} --debug --main-module ETHEREUM-SIMULATION \
-					--syntax-module ETHEREUM-SIMULATION $< --directory .build/rvk \
+	${KOMPILE} --debug --main-module ETHEREUM \
+					--syntax-module ETHEREUM $< --directory .build/rvk \
 					--hook-namespaces KRYPTO --packages iele-semantics-plugin -O3 --non-strict
 	cd .build/rvk/ethereum-kompiled && ocamlfind opt -o interpreter constants.cmx prelude.cmx plugin.cmx parser.cmx lexer.cmx run.cmx interpreter.ml -package gmp -package dynlink -package zarith -package str -package uuidm -package unix -package iele-semantics-plugin -linkpkg -inline 20 -nodynlink -O3 -linkall

--- a/Makefile
+++ b/Makefile
@@ -109,15 +109,15 @@ deps:
 .build/rvk/ethereum-kompiled/extras/timestamp: .build/rvk/ethereum-kompiled/interpreter
 .build/rvk/ethereum-kompiled/interpreter: $(defn_files) KRYPTO.ml
 	@echo "== kompile: $@"
-	${KOMPILE} --debug --main-module ETHEREUM \
-					--syntax-module ETHEREUM $< --directory .build/rvk \
+	${KOMPILE} --debug --main-module ETHEREUM-SIMULATION \
+					--syntax-module IELE-SYNTAX $< --directory .build/rvk \
 					--hook-namespaces KRYPTO --gen-ml-only -O3 --non-strict
 	ocamlfind opt -c .build/rvk/ethereum-kompiled/constants.ml -package gmp -package zarith
 	ocamlfind opt -c -I .build/rvk/ethereum-kompiled KRYPTO.ml -package cryptokit -package secp256k1 -package bn128
 	ocamlfind opt -a -o semantics.cmxa KRYPTO.cmx
 	ocamlfind remove iele-semantics-plugin
 	ocamlfind install iele-semantics-plugin META semantics.cmxa semantics.a KRYPTO.cmi KRYPTO.cmx
-	${KOMPILE} --debug --main-module ETHEREUM \
-					--syntax-module ETHEREUM $< --directory .build/rvk \
+	${KOMPILE} --debug --main-module ETHEREUM-SIMULATION \
+					--syntax-module IELE-SYNTAX $< --directory .build/rvk \
 					--hook-namespaces KRYPTO --packages iele-semantics-plugin -O3 --non-strict
 	cd .build/rvk/ethereum-kompiled && ocamlfind opt -o interpreter constants.cmx prelude.cmx plugin.cmx parser.cmx lexer.cmx run.cmx interpreter.ml -package gmp -package dynlink -package zarith -package str -package uuidm -package unix -package iele-semantics-plugin -linkpkg -inline 20 -nodynlink -O3 -linkall

--- a/ethereum.md
+++ b/ethereum.md
@@ -629,17 +629,5 @@ Here we check the other post-conditions associated with an EVM test.
     rule <k> check "genesisBlockHeader" : { "hash": HASH } => . ... </k>
          <blockhash> ... ListItem(HASH) ListItem(_) </blockhash>
 endmodule
-
-module ETHEREUM-PROGRAM-PARSING // module used by K for parsing programs
-  imports PROGRAM-LISTS         // to accept empty lists as in f()
-  imports IELE-SYNTAX           // including lexical syntax for Names
-  imports ETHEREUM-SIMULATION   // including all the rest of the syntax
-endmodule
-
-module ETHEREUM
-  //program parsing module needs to be reachable from main module
-  imports ETHEREUM-PROGRAM-PARSING
-endmodule
-
 ```
 

--- a/ethereum.md
+++ b/ethereum.md
@@ -629,5 +629,17 @@ Here we check the other post-conditions associated with an EVM test.
     rule <k> check "genesisBlockHeader" : { "hash": HASH } => . ... </k>
          <blockhash> ... ListItem(HASH) ListItem(_) </blockhash>
 endmodule
+
+module ETHEREUM-PROGRAM-PARSING // module used by K for parsing programs
+  imports PROGRAM-LISTS         // to accept empty lists as in f()
+  imports IELE-SYNTAX           // including lexical syntax for Names
+  imports ETHEREUM-SIMULATION   // including all the rest of the syntax
+endmodule
+
+module ETHEREUM
+  //program parsing module needs to be reachable from main module
+  imports ETHEREUM-PROGRAM-PARSING
+endmodule
+
 ```
 

--- a/iele-syntax.md
+++ b/iele-syntax.md
@@ -19,7 +19,7 @@ IELE uses alphanumeric names for identifying registers, labels, functions, and c
 module IELE-SYNTAX
   imports IELE-COMMON
 
-  syntax IeleName ::= r"(?<![A-Za-z0-9\\_\\.\\-\\$])[a-zA-Z\\.\\_\\-\\$][0-9a-zA-Z\\.\\_\\-\\$]*" [token]
+  syntax IeleName ::= r"(?<![A-Za-z0-9\\_\\.\\-\\$])[a-zA-Z\\.\\_\\-\\$][0-9a-zA-Z\\.\\_\\-\\$]*" [token, notInRules, prec(3)]
 
   syntax NumericIeleName ::= r"[0-9]+" [token]
 endmodule


### PR DESCRIPTION
This should be enough to make kast work.

apaprently `kast` is looking for a `<MODULE>-PROGRAM-PARSING` and if it does not find one, it generates one including `ID-PROGRAM-PARSING` syntax which contains some token rules with higher precedence than ours.  That is why the `IeleName`s ended up being parsed as `Id`s and `kast` reported an error. 