### PR TITLE
Downgrade version of secp256k1 to install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ ocaml-deps:
 	opam repository add k "tests/ci/rv-k/k-distribution/target/release/k/lib/opam" || opam repository set-url k "tests/ci/rv-k/k-distribution/target/release/k/lib/opam"
 	opam update
 	opam switch 4.03.0+k
-	eval `opam config env` && opam install -y mlgmp zarith uuidm cryptokit secp256k1 bn128 hex ocaml-protoc rlp yojson
+	eval `opam config env` && opam install -y mlgmp zarith uuidm cryptokit secp256k1.0.3.2 bn128 hex ocaml-protoc rlp yojson
 
 .build/%/ethereum-kompiled/constants.$(EXT): $(defn_files)
 	@echo "== kompile: $@"


### PR DESCRIPTION
The secp256k1 opam package seems to still be in flux with respect to its public API.

We are fixing this to a specific version so that if it changes again, it will not break
new installs.