### PR TITLE
python scripts: Change shebang to call `python2` instead of `python`

### DIFF
--- a/assemble-iele-test
+++ b/assemble-iele-test
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import subprocess
 import sys

--- a/kast-json.py
+++ b/kast-json.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import json
 import sys

--- a/tests/evm-to-iele/evm-test-to-iele
+++ b/tests/evm-to-iele/evm-test-to-iele
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import subprocess
 import sys

--- a/tests/split-test.py
+++ b/tests/split-test.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-
+#!/usr/bin/env python2
 
 import sys
 import json


### PR DESCRIPTION
This allows running of IELE code on machines with both python2 and python3
installed.