### PR TITLE
don't leak return values when we revert

### DIFF
--- a/iele.md
+++ b/iele.md
@@ -1017,6 +1017,7 @@ When execution of the callee reaches a `ret` instruction, control returns to the
          <localCalls> ListItem({ OPS | FUNC | RETURNS | REGS }) => .List ... </localCalls>
 
     rule <k> #exec revert VALUE => #revert VALUE ... </k>
+         <output> _ => .Ints </output>
 ```
 
 ### Log Operations


### PR DESCRIPTION
Previously a bug existed where if a contract called another contract and then reverted, the values returned to the parent contract contained the values returned by the nested contract call. This is obviously not the intended behavior, and so I created a fix for it.