### PR TITLE
Function pointers in IELE

### DIFF
--- a/check-iele
+++ b/check-iele
@@ -3,7 +3,7 @@ interpreter="$(dirname "$0")/.build/check/well-formedness-kompiled/interpreter"
 kast="$(mktemp)"
 trap "rm -rf $kast" INT TERM EXIT
 "$(dirname "$0")/tests/ci/rv-k/k-distribution/target/release/k/bin/kast" -s Contract --expand-macros -d "$(dirname "$0")/.build/check" "$1" > "$kast"
-$interpreter "$(dirname "$0")/.build/check/well-formedness-kompiled/realdef.cma" -c PGM "$kast" textfile
+$interpreter "$(dirname "$0")/.build/check/well-formedness-kompiled/realdef.cma" -c PGM "$kast" textfile "$@"
 exit=$?
 if [ $exit -eq 0 ]; then
   exit 0

--- a/compiler/src/IeleAssembler.hs
+++ b/compiler/src/IeleAssembler.hs
@@ -112,8 +112,11 @@ asm_iele_opcode_li opLi = case opLi of
 asm_iele_opcode_call :: IeleOpcodeCall Word16 Word16 -> Put
 asm_iele_opcode_call opCall = case opCall of
   CALL call nargs nreturn -> putWord8 0xf2 >> putWord16be call >> putArgs16 nargs >> putRets16 nreturn
+  CALLDYN nargs nreturn -> putWord8 0xf3 >> putArgs16 nargs >> putRets16 nreturn
   STATICCALL call nargs nreturn -> putWord8 0xf5 >> putWord16be call >> putArgs16 nargs >> putRets16 nreturn
+  STATICCALLDYN nargs nreturn -> putWord8 0xf9 >> putArgs16 nargs >> putRets16 nreturn
   LOCALCALL call nargs nreturn -> putWord8 0xf8 >> putWord16be call >> putArgs16 nargs >> putRets16 nreturn
+  LOCALCALLDYN nargs nreturn -> putWord8 0xf4 >> putArgs16 nargs >> putRets16 nreturn
 
   CREATE contract nargs -> putWord8 0xf0 >> putWord16be contract >> putArgs16 nargs
   COPYCREATE nargs -> putWord8 0xf1 >> putArgs16 nargs

--- a/compiler/src/IeleAssembler.hs
+++ b/compiler/src/IeleAssembler.hs
@@ -114,9 +114,9 @@ asm_iele_opcode_call opCall = case opCall of
   CALL call nargs nreturn -> putWord8 0xf2 >> putWord16be call >> putArgs16 nargs >> putRets16 nreturn
   CALLDYN nargs nreturn -> putWord8 0xf3 >> putArgs16 nargs >> putRets16 nreturn
   STATICCALL call nargs nreturn -> putWord8 0xf5 >> putWord16be call >> putArgs16 nargs >> putRets16 nreturn
-  STATICCALLDYN nargs nreturn -> putWord8 0xf9 >> putArgs16 nargs >> putRets16 nreturn
+  STATICCALLDYN nargs nreturn -> putWord8 0xf4 >> putArgs16 nargs >> putRets16 nreturn
   LOCALCALL call nargs nreturn -> putWord8 0xf8 >> putWord16be call >> putArgs16 nargs >> putRets16 nreturn
-  LOCALCALLDYN nargs nreturn -> putWord8 0xf4 >> putArgs16 nargs >> putRets16 nreturn
+  LOCALCALLDYN nargs nreturn -> putWord8 0xf9 >> putArgs16 nargs >> putRets16 nreturn
 
   CREATE contract nargs -> putWord8 0xf0 >> putWord16be contract >> putArgs16 nargs
   COPYCREATE nargs -> putWord8 0xf1 >> putArgs16 nargs

--- a/compiler/src/IeleDesugar.hs
+++ b/compiler/src/IeleDesugar.hs
@@ -44,8 +44,8 @@ expandImmediates inst =
   in reverse loads++[inst']
 
 desugarFundef :: Map GlobalName Integer
-              -> FunctionDefinition Word16 IeleName LValue (IeleOpG IeleName Word16 IeleName LValue Operand)
-              -> FunctionDefinitionD IeleName Word16 IeleName LValue
+              -> FunctionDefinitionD IeleName Word16 IeleName LValue Operand
+              -> FunctionDefinitionD IeleName Word16 IeleName LValue LValue
 desugarFundef globals fundef =
   fundef & functionInsts %~ concatMap expandImmediates
                           . (traverse . ieleOpArg %~ lookupGlobal globals)
@@ -74,8 +74,8 @@ applyIeleNameMap _ (IeleNameNumber n) = n
 applyIeleNameMap mapping (IeleNameText t)
   | Just ix <- Map.lookup t mapping = ix
 
-numberBlocks :: FunctionDefinitionD conId funId IeleName reg
-             -> FunctionDefinitionD conId funId Word16 reg
+numberBlocks :: FunctionDefinitionD conId funId IeleName reg reg
+             -> FunctionDefinitionD conId funId Word16 reg reg
 numberBlocks funDef =
   let rename = fromIntegral . applyIeleNameMap (numberIeleNames (funDef ^.. blocks . traverse . label))
   in funDef & blocks . traverse . label %~ rename
@@ -88,8 +88,8 @@ assignLocals args bodyRefs =
       namedArgs = [(t,ix) | (IeleNameText t,ix) <- zip args [0..]]
   in extendAssignment (Map.fromList namedArgs) usedNums usedNames
 
-numberLocals :: FunctionDefinitionD conId funId blkId LValue
-             -> FunctionDefinitionD conId funId blkId Int
+numberLocals :: FunctionDefinitionD conId funId blkId LValue LValue
+             -> FunctionDefinitionD conId funId blkId Int Int
 numberLocals funDef =
   let funLocalRegs f = (functionInsts . traverse . ieleOpRegs') f
       funParams f = (parameters . traverse) f
@@ -107,7 +107,7 @@ setNub l = go Set.empty l
                         else x:go (Set.insert x acc) xs
 
 numberFunctions :: [FunctionDefinitionP]
-                -> ([String],(Map IeleName Word16),[FunctionDefinition Word16 IeleName LValue (IeleOpG IeleName Word16 IeleName LValue Operand)])
+                -> ([String],(Map IeleName Word16),[FunctionDefinitionD IeleName Word16 IeleName LValue Operand])
 numberFunctions fundefs =
   let declaredFuns = fundefs ^.. traverse . name . _GlobalName
       calledFuns = fundefs ^.. traverse . functionInsts . traverse . ieleOpFunId . _GlobalName
@@ -122,8 +122,8 @@ numberFunctions fundefs =
 
 numberContracts :: [IeleName]
                 -> [String]
-                -> [FunctionDefinitionD IeleName Word16 blk reg]
-                -> [FunctionDefinitionD Word16 Word16 blk reg]
+                -> [FunctionDefinitionD IeleName Word16 blk reg reg]
+                -> [FunctionDefinitionD Word16 Word16 blk reg reg]
 numberContracts declaredContracts functionNames fundefs =
   let nextId = length functionNames + 1
       contractMapping = Map.fromList (zip declaredContracts [fromIntegral nextId..])
@@ -142,7 +142,7 @@ processContract (ContractP name _ definitions) =
       funDefsD = numberContracts externalContracts functionNames funDefs'
   in (name, ContractD functionNames externalContracts funDefsD)
 
-flattenFundef :: FunctionDefinitionD Word16 Word16 Word16 Int -> [IeleOp]
+flattenFundef :: FunctionDefinitionD Word16 Word16 Word16 Int Int -> [IeleOp]
 flattenFundef (FunctionDefinition isPublic name args entry blocks) =
   VoidOp ((if isPublic then EXTCALLDEST else CALLDEST) name (argsLength args)) []
   :entry++concatMap flattenBlock blocks

--- a/compiler/src/IeleInstructions.hs
+++ b/compiler/src/IeleInstructions.hs
@@ -182,9 +182,12 @@ data IeleOpcodeLi =
   deriving (Show, Eq, Data)
 
 data IeleOpcodeCall contractId funId =
-   CALL funId (Args Word16) (Rets  Word16)
+   CALL funId (Args Word16) (Rets Word16)
+ | CALLDYN (Args Word16) (Rets Word16)
  | STATICCALL funId (Args Word16) (Rets Word16)
+ | STATICCALLDYN (Args Word16) (Rets Word16)
  | LOCALCALL funId (Args Word16) (Rets Word16)
+ | LOCALCALLDYN (Args Word16) (Rets Word16)
 
  | CREATE contractId (Args Word16) -- contract Id
  | COPYCREATE (Args Word16)
@@ -197,8 +200,11 @@ retypeOpcodeCall :: (Applicative f)
                  -> f (IeleOpcodeCall contractId' funId')
 retypeOpcodeCall contract fun i = case i of
     CALL f nargs nrets -> (\f -> CALL f nargs nrets) <$> fun f
+    CALLDYN nargs nrets -> pure (CALLDYN nargs nrets)
     STATICCALL f nargs nrets -> (\f -> STATICCALL f nargs nrets) <$> fun f
+    STATICCALLDYN nargs nrets -> pure (STATICCALLDYN nargs nrets)
     LOCALCALL f nargs nrets -> (\f -> LOCALCALL f nargs nrets) <$> fun f
+    LOCALCALLDYN nargs nrets -> pure (LOCALCALLDYN nargs nrets)
     CREATE c nargs -> (\c -> CREATE c nargs) <$> contract c
     COPYCREATE nargs -> pure (COPYCREATE nargs)
 

--- a/compiler/src/IelePrint.hs
+++ b/compiler/src/IelePrint.hs
@@ -64,7 +64,7 @@ prettyContractD (cname, ContractD functionNames externalContracts functionDefini
   ++intersperse blank (map (prettyFunDef . formatDef) functionDefinitions)
  where
   numToLValue n = LValueLocalName (LocalName (IeleNameNumber n))
-  formatDef :: FunctionDefinitionD Word16 Word16 Word16 Int
+  formatDef :: FunctionDefinitionD Word16 Word16 Word16 Int Int
             -> FunctionDefinition GlobalName IeleName LValue Doc
   formatDef def = def & name %~ GlobalName . IeleNameNumber . fromIntegral
                       & parameters . traverse %~ numToLValue

--- a/compiler/src/IelePrint.hs
+++ b/compiler/src/IelePrint.hs
@@ -123,6 +123,9 @@ prettyIeleInst (LiOp LOADNEG tgt i) = inst [tgt] empty [integer (negate i)]
 prettyIeleInst (CallOp (LOCALCALL name _ _) results args) =
   prettyResults results <+> text "call" <+> prettyName name
     <> char '(' <> commaList args <> char ')'
+prettyIeleInst (CallOp (LOCALCALLDYN  _ _) results (name : args)) =
+  prettyResults results <+> text "call" <+> name
+    <> char '(' <> commaList args <> char ')'
 prettyIeleInst (CallOp (CALL name _ _) results allArgs) = case results of
   [] -> error "external call instruction must have at least one result"
   _ -> case allArgs of
@@ -132,15 +135,33 @@ prettyIeleInst (CallOp (CALL name _ _) results allArgs) = case results of
              <> char '(' <> commaList args <> char ')'
              <+> text "send" <+> val <> comma <+> text "gaslimit" <+> gas
          _ -> error "external call instruction must encode at least target, gaslimit, and value arguments"
-prettyIeleInst (CallOp (STATICCALL name _ _) results allArgs) = case results of
+prettyIeleInst (CallOp (CALLDYN _ _) results allArgs) = case results of
   [] -> error "external call instruction must have at least one result"
   _ -> case allArgs of
-         (gas:acct:val:args) ->
-           prettyResults results <+> text "staticcall" <+> prettyName name
+         (name:gas:acct:val:args) ->
+           prettyResults results <+> text "call" <+> name
              <+> text "at" <+> acct
              <> char '(' <> commaList args <> char ')'
              <+> text "send" <+> val <> comma <+> text "gaslimit" <+> gas
-         _ -> error "external staticcall instruction must encode at least target, gaslimit, and value arguments"
+         _ -> error "external call instruction must encode at least target, gaslimit, and value arguments"
+prettyIeleInst (CallOp (STATICCALL name _ _) results allArgs) = case results of
+  [] -> error "external call instruction must have at least one result"
+  _ -> case allArgs of
+         (gas:acct:args) ->
+           prettyResults results <+> text "staticcall" <+> prettyName name
+             <+> text "at" <+> acct
+             <> char '(' <> commaList args <> char ')'
+             <+> text "gaslimit" <+> gas
+         _ -> error "external staticcall instruction must encode at least target and gaslimit arguments"
+prettyIeleInst (CallOp (STATICCALLDYN _ _) results allArgs) = case results of
+  [] -> error "external call instruction must have at least one result"
+  _ -> case allArgs of
+         (name:gas:acct:args) ->
+           prettyResults results <+> text "staticcall" <+> name
+             <+> text "at" <+> acct
+             <> char '(' <> commaList args <> char ')'
+             <+> text "gaslimit" <+> gas
+         _ -> error "external staticcall instruction must encode at least target and gaslimit arguments"
 prettyIeleInst (CallOp (CREATE name _) results (val:args)) = case results of
   [status,addr] ->
     prettyResults [status,addr] <+> text "create"

--- a/compiler/src/IeleTypes.hs
+++ b/compiler/src/IeleTypes.hs
@@ -173,13 +173,13 @@ data ContractP = ContractP
   }
   deriving (Show, Eq, Data)
 
-type FunctionDefinitionD contract funId blkId reg =
-  FunctionDefinition funId blkId reg (IeleOpG contract funId blkId reg reg)
+type FunctionDefinitionD contract funId blkId lval op =
+  FunctionDefinition funId blkId lval (IeleOpG contract funId blkId lval op)
 
 data ContractD contractId = ContractD
   { functionNames :: [String]
   , externalContracts :: [contractId]
-  , functionDefinitions :: [FunctionDefinitionD Word16 Word16 Word16 Int]
+  , functionDefinitions :: [FunctionDefinitionD Word16 Word16 Word16 Int Int]
   }
 
 makePrisms ''TopLevelDefinition

--- a/data.md
+++ b/data.md
@@ -133,10 +133,12 @@ You could alternatively calculate `I1 %Int I2`, then add one to the normal integ
 -   `logNInt` returns the log base N (floored) of an integer.
 
 ```k
-    syntax Int ::= log2Int ( Int ) [function]
- // -----------------------------------------
-    rule log2Int(1) => 0
-    rule log2Int(W) => 1 +Int log2Int(W >>Int 1) requires W >Int 1
+    syntax Int ::= log2Int ( Int )       [function]
+                 | log2Int ( Int , Int ) [function, klabel(log2IntAux)]
+ // -------------------------------------------------------------------
+    rule log2Int(I) => log2Int(I, 0)
+    rule log2Int(1, N) => N
+    rule log2Int(W, N) => log2Int(W >>Int 1, N +Int 1) requires W >Int 1
 
     syntax Int ::= log256Int ( Int ) [function]
  // -------------------------------------------

--- a/ethereum.md
+++ b/ethereum.md
@@ -144,7 +144,7 @@ To do so, we'll extend sort `JSON` with some IELE specific syntax, and provide a
          </account>
 
     rule <k> loadTx(ACCTFROM)
-          => #call ACCTFROM ACCTTO FUNC (GLIMIT -Int G0(SCHED, IeleName2String(FUNC), ARGS)) VALUE ARGS false
+          => #call ACCTFROM ACCTTO @ FUNC (GLIMIT -Int G0(SCHED, IeleName2String(FUNC), ARGS)) VALUE ARGS false
           ~> #finishTx ~> #adjustGas ~> #finalizeTx(false) ~> startTx
          ...
          </k>

--- a/iele-binary.md
+++ b/iele-binary.md
@@ -183,9 +183,9 @@ After interpreting the strings representing programs as a `WordStack`, it should
     rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, 242 : W1 : W2 : W3 : W4 : W5 : W6 : WS, NBITS, FUNCS, INSTRS, .K) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, CALL(W1 *Int 256 +Int W2, W3 *Int 256 +Int W4, W5 *Int 256 +Int W6))
     rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, 243 : W1 : W2 : W3 : W4 : WS, NBITS, FUNCS, INSTRS, .K) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, CALLDYN(W1 *Int 256 +Int W2, W3 *Int 256 +Int W4))
     rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, 245 : W1 : W2 : W3 : W4 : W5 : W6 : WS, NBITS, FUNCS, INSTRS, .K) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, STATICCALL(W1 *Int 256 +Int W2, W3 *Int 256 +Int W4, W5 *Int 256 +Int W6))
-    rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, 249 : W1 : W2 : W3 : W4 : WS, NBITS, FUNCS, INSTRS, .K) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, STATICCALLDYN(W1 *Int 256 +Int W2, W3 *Int 256 +Int W4))
+    rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, 244 : W1 : W2 : W3 : W4 : WS, NBITS, FUNCS, INSTRS, .K) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, STATICCALLDYN(W1 *Int 256 +Int W2, W3 *Int 256 +Int W4))
     rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, 248 : W1 : W2 : W3 : W4 : W5 : W6 : WS, NBITS, FUNCS, INSTRS, .K) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, LOCALCALL(W1 *Int 256 +Int W2, W3 *Int 256 +Int W4, W5 *Int 256 +Int W6))
-    rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, 244 : W1 : W2 : W3 : W4 : WS, NBITS, FUNCS, INSTRS, .K) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, LOCALCALLDYN(W1 *Int 256 +Int W2, W3 *Int 256 +Int W4))
+    rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, 249 : W1 : W2 : W3 : W4 : WS, NBITS, FUNCS, INSTRS, .K) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, LOCALCALLDYN(W1 *Int 256 +Int W2, W3 *Int 256 +Int W4))
 
     syntax Blocks ::= #toBlocks ( Instructions ) [function]
                     | #toBlocks ( Instructions , Blocks ) [function, klabel(#toBlockAux)]

--- a/iele-gas.md
+++ b/iele-gas.md
@@ -210,6 +210,13 @@ to the function, which consume as much as the size of their arguments.
          <schedule> SCHED </schedule>
          <funcId> NAME </funcId>
          <nregs> REGISTERS </nregs>
+
+    rule <k> #memory [ _ = call (IDX:Int => @ FUNC) ( _ ) ] ... </k>
+         <funcLabels> ... IDX |-> FUNC ... </funcLabels>
+    // this will throw an exception, so the gas cost doesn't really matter
+    rule <k> #memory [ _ = call IDX:Int ( _ ) ] => . ... </k>
+         <funcLabels> LABELS </funcLabels>
+      requires notBool IDX in_keys(LABELS)
 ```
 
 The memory cost of returning to a function is negative. Instead of charging a gas cost, memory is reclaimed according to the
@@ -543,6 +550,12 @@ constant cost to perform the jump and store the return address.
     rule <k> #compute [ _ = call @ NAME ( ARGS ), SCHED ] => Gcallreg < SCHED > *Int REGISTERS +Int intSizes(ARGS) *Int Gcopy < SCHED > +Int Glocalcall < SCHED > ... </k>
          <funcId> NAME </funcId>
          <nregs> REGISTERS </nregs>
+    rule <k> #compute [ _ = call (IDX:Int => @ FUNC) ( _ ), _ ] ... </k>
+         <funcLabels> ... IDX |-> FUNC ... </funcLabels>
+    // this will throw an exception, so the gas cost doesn't really matter
+    rule <k> #compute [ _ = call IDX:Int ( _ ), _ ] => 0 ... </k>
+         <funcLabels> LABELS </funcLabels>
+      requires notBool IDX in_keys(LABELS)
 ```
 
 The cost to return from an intra-contract call is the cost to move the return values into the result registers plus the cost to

--- a/iele-node.md
+++ b/iele-node.md
@@ -81,7 +81,7 @@ module IELE-NODE
       requires ACCTFROM in ACCTS
 
     rule <k> runVM(false, ACCTTO, ACCTFROM, _, ARGS, VALUE, GPRICE, GAVAIL, CB, DIFF, NUMB, GLIMIT, TS, FUNC)
-          => #call ACCTFROM ACCTTO {#parseToken("IeleName", FUNC)}:>IeleName GAVAIL VALUE #toInts(ARGS) false
+          => #call ACCTFROM ACCTTO @ {#parseToken("IeleName", FUNC)}:>IeleName GAVAIL VALUE #toInts(ARGS) false
           ~> #endVM
          ...
          </k>

--- a/iele-syntax.md
+++ b/iele-syntax.md
@@ -179,12 +179,12 @@ Instructions for conditional and unconditional jumps within the function's body.
 Instructions for local functions calls to other functions of the same contract, as well as contract function calls to public functions of contracts deployed in other accounts. For more details see [here](Design.md#function-callreturn).
 
 ```k
-  syntax LocalCallInst   ::= "call" GlobalName "(" Operands ")"
-                           | LValues "=" "call" GlobalName "(" Operands ")" [hybrid, strict(3)]
-  syntax AccountCallInst ::= "call" GlobalName "at" Operand "(" Operands ")" "send" Operand "," "gaslimit" Operand
-                           | LValues "=" "call" GlobalName "at" Operand "(" Operands ")" "send" Operand "," "gaslimit" Operand [hybrid, seqstrict(3,4,5,6)]
-  syntax AccountCallInst ::= "staticcall" GlobalName "at" Operand "(" Operands ")" "gaslimit" Operand
-                           | LValues "=" "staticcall" GlobalName "at" Operand "(" Operands ")" "gaslimit" Operand [hybrid, seqstrict(3,4,5)]
+  syntax LocalCallInst   ::= "call" Operand "(" Operands ")"
+                           | LValues "=" "call" Operand "(" Operands ")" [hybrid, strict(2,3)]
+  syntax AccountCallInst ::= "call" Operand "at" Operand "(" Operands ")" "send" Operand "," "gaslimit" Operand
+                           | LValues "=" "call" Operand "at" Operand "(" Operands ")" "send" Operand "," "gaslimit" Operand [hybrid, seqstrict(2,3,4,5,6)]
+  syntax AccountCallInst ::= "staticcall" Operand "at" Operand "(" Operands ")" "gaslimit" Operand
+                           | LValues "=" "staticcall" Operand "at" Operand "(" Operands ")" "gaslimit" Operand [hybrid, seqstrict(2,3,4,5)]
 
   syntax ReturnInst ::= "ret" NonEmptyOperands [hybrid, strict(1)]
                       | "ret" "void"

--- a/tests/iele/unit/fptr.iele
+++ b/tests/iele/unit/fptr.iele
@@ -1,0 +1,55 @@
+contract test {
+  define public @test() {
+    %func = @test2
+    %ret = call %func()
+    br %ret, throw
+    %addr = call @iele.address()
+    %gas = call @iele.gas()
+    %status, %ret = call %func at %addr() send 0, gaslimit %gas
+    br %status, throw
+    br %ret, throw
+    %status, %ret = staticcall %func at %addr() gaslimit %gas
+    br %status, throw
+    br %ret, throw
+
+    %gas = 10000
+    %status = call @testfail at %addr() send 0, gaslimit %gas
+    %cmp = cmp ne %status, 1
+    br %cmp, throw
+
+    %status = call @testfail2 at %addr() send 0, gaslimit %gas
+    %cmp = cmp ne %status, 2
+    br %cmp, throw
+    ret void
+  throw:
+    revert -1
+  }
+
+  define @init () {}
+
+  define public @test2() {
+    ret 0
+  }
+
+  define public @testfail() {
+    %func = 15
+    %addr = call @iele.address()
+    %gas = 1000
+    %status, %ret = call %func at %addr() send 0, gaslimit %gas
+    %cmp = cmp ne %status, 1
+    br %cmp, throw
+    br %ret, throw
+    %status, %ret = staticcall %func at %addr() gaslimit %gas
+    %cmp = cmp ne %status, 1
+    br %cmp, throw
+    br %ret, throw
+    %ret = call %func()
+  throw:
+    revert -1
+  }
+
+  define public @testfail2() {
+    %func = @test2
+    %ret = call %func(0)
+  }
+}

--- a/tests/iele/unit/fptr.iele
+++ b/tests/iele/unit/fptr.iele
@@ -1,6 +1,8 @@
 contract test {
   define public @test() {
     %func = @test2
+    store %func, 0
+    %func = load 0
     %ret = call %func()
     br %ret, throw
     %addr = call @iele.address()

--- a/tests/iele/unit/fptr.iele.json
+++ b/tests/iele/unit/fptr.iele.json
@@ -21,7 +21,7 @@
                     {
                         "out": [],
                         "status": "",
-                        "gas": "0x0f527f",
+                        "gas": "0x0f526d",
                         "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
                         "refund": ""
                     }

--- a/tests/iele/unit/fptr.iele.json
+++ b/tests/iele/unit/fptr.iele.json
@@ -1,0 +1,69 @@
+{
+    "BLOCKHASH": {
+        "pre": {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+                "nonce": "0x00",
+                "balance": "0xe8d4a51000",
+                "storage": {},
+                "code": ""
+            },
+            "0x1000000000000000000000000000000000000000": {
+                "nonce": "0x00", 
+                "balance": "0x00", 
+                "storage": {
+                },
+                "code": "fptr.iele"
+            }
+        },
+        "blocks": [
+            {
+                "results": [
+                    {
+                        "out": [],
+                        "status": "",
+                        "gas": "0x0f527f",
+                        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
+                        "refund": ""
+                    }
+                ],
+                "transactions": [
+                    {
+                        "nonce": "0x00", 
+                        "function": "test",
+                        "gasLimit": "0x100000", 
+                        "value": "0x00", 
+                        "to": "0x1000000000000000000000000000000000000000", 
+                        "arguments": [],
+                        "contractCode": "",
+                        "gasPrice": "0x01",
+                        "from": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
+                    }
+                ], 
+                "blockHeader": {
+                    "gasLimit": "0x174876e800", 
+                    "number": "0x01", 
+                    "difficulty": "0x020000", 
+                    "timestamp": "0x03e8", 
+                    "coinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba"
+                }
+            }
+        ], 
+        "network": "Albe", 
+        "blockhashes": ["0x24a30e4305ac41674b26493c800c05f507e98d3b8bceb0a314f9b9bc43622736", "0x00"],
+        "postState": {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+                "nonce": "0x01",
+                "balance": "0xe8d4951000",
+                "storage": {},
+                "code": ""
+            },
+            "0x1000000000000000000000000000000000000000": {
+                "nonce": "0x00", 
+                "balance": "0x00", 
+                "storage": {
+                }, 
+                "code": "fptr.iele"
+            }
+        }
+    }
+}

--- a/well-formedness.md
+++ b/well-formedness.md
@@ -252,8 +252,10 @@ Checking these instructions requires checking the types of local function calls 
          <types> ... NAME |-> ARGTYPES -> (unknown => ints(#sizeLVals(RETS))) </types>
       requires ints(#sizeRegs(ARGS)) ==K ARGTYPES
 
-    rule check ~> STATUS, RETS = call @ NAME at OP1 ( ARGS ) send OP2 , gaslimit OP3 => checkLVals(STATUS, RETS) ~> checkOperands(OP1 , OP2 , OP3 , ARGS)
-    rule check ~> STATUS, RETS = staticcall @ NAME at OP1 ( ARGS ) gaslimit OP2 => checkLVals(STATUS, RETS) ~> checkOperands(OP1 , OP2 , ARGS)
+    rule <k> check ~> RETS = call % NAME ( ARGS ) => checkLVals(RETS) ~> checkOperands(ARGS) ... </k>
+
+    rule check ~> STATUS, RETS = call NAME at OP1 ( ARGS ) send OP2 , gaslimit OP3 => checkLVals(STATUS, RETS) ~> checkOperands(OP1 , OP2 , OP3 , ARGS)
+    rule check ~> STATUS, RETS = staticcall NAME at OP1 ( ARGS ) gaslimit OP2 => checkLVals(STATUS, RETS) ~> checkOperands(OP1 , OP2 , ARGS)
 
     rule <k> check ~> ret OPS => checkOperands(OPS) ... </k>
          <functionName> NAME </functionName>
@@ -349,8 +351,7 @@ Checking Operands
 
     rule checkOperand(% NAME) => .
     rule checkOperand(_:IntConstant) => .
-    rule <k> checkOperand(@ NAME) => . ... </k>
-         <types> ... NAME |-> int </types>
+    rule checkOperand(@ NAME) => .
 ```
 
 Checking LValues


### PR DESCRIPTION
Per our previous discussion, this PR adds function pointers to IELE by allowing global function names anywhere an operand can be used in the assembler, and adding semantics for dynamic call targets computed from an integer function offset.