### PR TITLE
Metadata stamp for binary representation.

### DIFF
--- a/compiler/src/IeleAssembler.hs
+++ b/compiler/src/IeleAssembler.hs
@@ -165,4 +165,9 @@ asm_iele ops = mapM_ (asm_iele_op nregs) ops
   where nregs = case ops of (VoidOp (REGISTERS n) []:_) -> n; _ -> 5
 
 assemble :: [IeleOp] -> B.ByteString
-assemble ops = runPut (asm_iele ops)
+assemble ops = runPut (put_byte_length (B.length bytes) >> putByteString bytes)
+  where bytes = runPut (asm_iele ops)
+        put_byte_length len
+          | len < 2^32 = putWord32be (fromIntegral len)
+          | otherwise = error "Contract byte length does not fit in 4 bytes"
+

--- a/iele-binary.md
+++ b/iele-binary.md
@@ -134,7 +134,6 @@ After interpreting the strings representing programs as a `WordStack`, it should
     rule #dasmContract( .WordStack, _) => #emptyCode
     rule #dasmContract( W1 : W2 : W3 : W4 : 99 : WS, NAME) => #dasmContract(99 : #take( W1 *Int 16777216  +Int W2 *Int 65536 +Int W3 *Int 256 +Int W4 -Int 1, WS), NAME, W1 : W2 : W3 : W4 : .WordStack)
     rule #dasmContract( 99 : NBITS : WS, NAME, W1 : W2 : W3 : W4 : .WordStack ) => #dasmContract(WS, NBITS, 0 |-> init, NAME, .TopLevelDefinitions, 1, #sizeWordStack(WS) +Int 6 , #unparseByteStack(W1 : W2 : W3 : W4 : 99 : NBITS : WS))
-    rule #dasmContract( 99 : NBITS : WS, NAME ) => #dasmContract(WS, NBITS, 0 |-> init, NAME, .TopLevelDefinitions, 1, #sizeWordStack(WS) +Int 2 , #unparseByteStack(99 : NBITS : WS))
     rule #dasmContract( 105 : W1 : W2 : WS, NBITS, FUNCS, NAME, DEFS, N, SIZE, BYTES ) => #dasmContract(#drop(W1 *Int 256 +Int W2, WS), NBITS, N |-> #parseToken("IeleName", #unparseByteStack(#take(W1 *Int 256 +Int W2, WS))) FUNCS, NAME, DEFS, N +Int 1, SIZE, BYTES )
     rule #dasmContract( 106 : W1 : W2 : WS, NBITS, FUNCS, NAME, DEFS, N, SIZE, BYTES ) => #dasmContract(#take(W1 *Int 256 +Int W2, WS), NAME +.+IeleName N) ++Contract #dasmContract(#drop(W1 *Int 256 +Int W2, WS), NBITS, FUNCS, NAME, external contract NAME +.+IeleName N DEFS, N +Int 1, SIZE, BYTES)
     rule #dasmContract( WS, NBITS, FUNCS, NAME, DEFS, N, SIZE, BYTES ) => contract NAME ! SIZE BYTES { DEFS ++TopLevelDefinitions #dasmFunctions(WS, NBITS, FUNCS, NAME) } .Contract [owise]

--- a/iele-binary.md
+++ b/iele-binary.md
@@ -128,10 +128,12 @@ After interpreting the strings representing programs as a `WordStack`, it should
 ```k
 
     syntax Contract ::= #dasmContract ( WordStack , IeleName )       [function]
-                      | #dasmContract ( WordStack , Int , Map, IeleName , TopLevelDefinitions, Int , Int , String ) [function, klabel(#dasmContractAux)]
+                      | #dasmContract ( WordStack , IeleName , WordStack ) [function, klabel(#dasmContractAux1)]
+                      | #dasmContract ( WordStack , Int , Map, IeleName , TopLevelDefinitions, Int , Int , String ) [function, klabel(#dasmContractAux2)]
  // ----------------------------------------------------------------------------------------------------------------------------------------------------
     rule #dasmContract( .WordStack, _) => #emptyCode
-    rule #dasmContract( W1 : W2 : W3 : W4 : 99 : WS, NAME) => #dasmContract(99 : #take( W1 *Int 16777216  +Int W2 *Int 65536 +Int W3 *Int 256 +Int W4 -Int 1, WS), NAME)
+    rule #dasmContract( W1 : W2 : W3 : W4 : 99 : WS, NAME) => #dasmContract(99 : #take( W1 *Int 16777216  +Int W2 *Int 65536 +Int W3 *Int 256 +Int W4 -Int 1, WS), NAME, W1 : W2 : W3 : W4 : .WordStack)
+    rule #dasmContract( 99 : NBITS : WS, NAME, W1 : W2 : W3 : W4 : .WordStack ) => #dasmContract(WS, NBITS, 0 |-> init, NAME, .TopLevelDefinitions, 1, #sizeWordStack(WS) +Int 6 , #unparseByteStack(W1 : W2 : W3 : W4 : 99 : NBITS : WS))
     rule #dasmContract( 99 : NBITS : WS, NAME ) => #dasmContract(WS, NBITS, 0 |-> init, NAME, .TopLevelDefinitions, 1, #sizeWordStack(WS) +Int 2 , #unparseByteStack(99 : NBITS : WS))
     rule #dasmContract( 105 : W1 : W2 : WS, NBITS, FUNCS, NAME, DEFS, N, SIZE, BYTES ) => #dasmContract(#drop(W1 *Int 256 +Int W2, WS), NBITS, N |-> #parseToken("IeleName", #unparseByteStack(#take(W1 *Int 256 +Int W2, WS))) FUNCS, NAME, DEFS, N +Int 1, SIZE, BYTES )
     rule #dasmContract( 106 : W1 : W2 : WS, NBITS, FUNCS, NAME, DEFS, N, SIZE, BYTES ) => #dasmContract(#take(W1 *Int 256 +Int W2, WS), NAME +.+IeleName N) ++Contract #dasmContract(#drop(W1 *Int 256 +Int W2, WS), NBITS, FUNCS, NAME, external contract NAME +.+IeleName N DEFS, N +Int 1, SIZE, BYTES)

--- a/iele-binary.md
+++ b/iele-binary.md
@@ -131,7 +131,7 @@ After interpreting the strings representing programs as a `WordStack`, it should
                       | #dasmContract ( WordStack , Int , Map, IeleName , TopLevelDefinitions, Int , Int , String ) [function, klabel(#dasmContractAux)]
  // ----------------------------------------------------------------------------------------------------------------------------------------------------
     rule #dasmContract( .WordStack, _) => #emptyCode
-    rule #dasmContract( W1 : W2 : W3 : W4 : 99 : WS, NAME) => #dasmContract(99 : #take( W1 *Int 16777216  +Int W2 *Int 65536 +Int W3 *Int 256 +Int W4, WS), NAME)
+    rule #dasmContract( W1 : W2 : W3 : W4 : 99 : WS, NAME) => #dasmContract(99 : #take( W1 *Int 16777216  +Int W2 *Int 65536 +Int W3 *Int 256 +Int W4 -Int 1, WS), NAME)
     rule #dasmContract( 99 : NBITS : WS, NAME ) => #dasmContract(WS, NBITS, 0 |-> init, NAME, .TopLevelDefinitions, 1, #sizeWordStack(WS) +Int 2 , #unparseByteStack(99 : NBITS : WS))
     rule #dasmContract( 105 : W1 : W2 : WS, NBITS, FUNCS, NAME, DEFS, N, SIZE, BYTES ) => #dasmContract(#drop(W1 *Int 256 +Int W2, WS), NBITS, N |-> #parseToken("IeleName", #unparseByteStack(#take(W1 *Int 256 +Int W2, WS))) FUNCS, NAME, DEFS, N +Int 1, SIZE, BYTES )
     rule #dasmContract( 106 : W1 : W2 : WS, NBITS, FUNCS, NAME, DEFS, N, SIZE, BYTES ) => #dasmContract(#take(W1 *Int 256 +Int W2, WS), NAME +.+IeleName N) ++Contract #dasmContract(#drop(W1 *Int 256 +Int W2, WS), NBITS, FUNCS, NAME, external contract NAME +.+IeleName N DEFS, N +Int 1, SIZE, BYTES)

--- a/iele-binary.md
+++ b/iele-binary.md
@@ -131,6 +131,7 @@ After interpreting the strings representing programs as a `WordStack`, it should
                       | #dasmContract ( WordStack , Int , Map, IeleName , TopLevelDefinitions, Int , Int , String ) [function, klabel(#dasmContractAux)]
  // ----------------------------------------------------------------------------------------------------------------------------------------------------
     rule #dasmContract( .WordStack, _) => #emptyCode
+    rule #dasmContract( W1 : W2 : W3 : W4 : 99 : WS, NAME) => #dasmContract(99 : #take( W1 *Int 16777216  +Int W2 *Int 65536 +Int W3 *Int 256 +Int W4, WS), NAME)
     rule #dasmContract( 99 : NBITS : WS, NAME ) => #dasmContract(WS, NBITS, 0 |-> init, NAME, .TopLevelDefinitions, 1, #sizeWordStack(WS) +Int 2 , #unparseByteStack(99 : NBITS : WS))
     rule #dasmContract( 105 : W1 : W2 : WS, NBITS, FUNCS, NAME, DEFS, N, SIZE, BYTES ) => #dasmContract(#drop(W1 *Int 256 +Int W2, WS), NBITS, N |-> #parseToken("IeleName", #unparseByteStack(#take(W1 *Int 256 +Int W2, WS))) FUNCS, NAME, DEFS, N +Int 1, SIZE, BYTES )
     rule #dasmContract( 106 : W1 : W2 : WS, NBITS, FUNCS, NAME, DEFS, N, SIZE, BYTES ) => #dasmContract(#take(W1 *Int 256 +Int W2, WS), NAME +.+IeleName N) ++Contract #dasmContract(#drop(W1 *Int 256 +Int W2, WS), NBITS, FUNCS, NAME, external contract NAME +.+IeleName N DEFS, N +Int 1, SIZE, BYTES)
@@ -153,7 +154,6 @@ After interpreting the strings representing programs as a `WordStack`, it should
  // ----------------------------------------------------------------------------------------------------------------------------
     rule #dasmFunctions(103 : W1 : W2 : W3 : W4 : WS, NBITS, FUNCS, NAME) => #dasmFunction(false, {FUNCS [ W1 *Int 256 +Int W2 ] orDefault W1 *Int 256 +Int W2}:>IeleName, NAME, W3 *Int 256 +Int W4, WS, NBITS, FUNCS, .Instructions, .K)
     rule #dasmFunctions(104 : W1 : W2 : W3 : W4 : WS, NBITS, FUNCS, NAME) => #dasmFunction(true, {FUNCS [ W1 *Int 256 +Int W2 ] orDefault W1 *Int 256 +Int W2}:>IeleName, NAME, W3 *Int 256 +Int W4, WS, NBITS, FUNCS, .Instructions, .K)
-    rule #dasmFunctions(107 : WS, NBITS, FUNCS, NAME) => .TopLevelDefinitions
     rule #dasmFunctions(.WordStack, NBITS, FUNCS, NAME) => .TopLevelDefinitions
 
     rule #dasmFunction(false, NAME, CNAME, SIG, W : WS, NBITS, FUNCS, INSTRS, .K) => define @ NAME ( SIG ) { #toBlocks(INSTRS) } #dasmFunctions(W : WS, NBITS, FUNCS, CNAME)
@@ -165,7 +165,7 @@ After interpreting the strings representing programs as a `WordStack`, it should
 
     rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, W : WS, NBITS, FUNCS, INSTRS, .K) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, #dasmOpCode(W))
       requires (W >=Int 0   andBool W <=Int 96)
-        orBool (W >=Int 108 andBool W <=Int 239)
+        orBool (W >=Int 107 andBool W <=Int 239)
         orBool (W >=Int 251 andBool W <=Int 255)
 
     rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, OP:OpCode) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, #drop(#opWidth(OP, NBITS) -Int #opCodeWidth(OP), WS), NBITS, FUNCS, #dasmInstruction(OP, #take(#opWidth(OP, NBITS) -Int #opCodeWidth(OP), WS), NBITS, FUNCS, CNAME) INSTRS, .K)

--- a/iele-binary.md
+++ b/iele-binary.md
@@ -153,6 +153,7 @@ After interpreting the strings representing programs as a `WordStack`, it should
  // ----------------------------------------------------------------------------------------------------------------------------
     rule #dasmFunctions(103 : W1 : W2 : W3 : W4 : WS, NBITS, FUNCS, NAME) => #dasmFunction(false, {FUNCS [ W1 *Int 256 +Int W2 ] orDefault W1 *Int 256 +Int W2}:>IeleName, NAME, W3 *Int 256 +Int W4, WS, NBITS, FUNCS, .Instructions, .K)
     rule #dasmFunctions(104 : W1 : W2 : W3 : W4 : WS, NBITS, FUNCS, NAME) => #dasmFunction(true, {FUNCS [ W1 *Int 256 +Int W2 ] orDefault W1 *Int 256 +Int W2}:>IeleName, NAME, W3 *Int 256 +Int W4, WS, NBITS, FUNCS, .Instructions, .K)
+    rule #dasmFunctions(107 : WS, NBITS, FUNCS, NAME) => .TopLevelDefinitions
     rule #dasmFunctions(.WordStack, NBITS, FUNCS, NAME) => .TopLevelDefinitions
 
     rule #dasmFunction(false, NAME, CNAME, SIG, W : WS, NBITS, FUNCS, INSTRS, .K) => define @ NAME ( SIG ) { #toBlocks(INSTRS) } #dasmFunctions(W : WS, NBITS, FUNCS, CNAME)
@@ -164,7 +165,7 @@ After interpreting the strings representing programs as a `WordStack`, it should
 
     rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, W : WS, NBITS, FUNCS, INSTRS, .K) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, #dasmOpCode(W))
       requires (W >=Int 0   andBool W <=Int 96)
-        orBool (W >=Int 107 andBool W <=Int 239)
+        orBool (W >=Int 108 andBool W <=Int 239)
         orBool (W >=Int 251 andBool W <=Int 255)
 
     rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, OP:OpCode) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, #drop(#opWidth(OP, NBITS) -Int #opCodeWidth(OP), WS), NBITS, FUNCS, #dasmInstruction(OP, #take(#opWidth(OP, NBITS) -Int #opCodeWidth(OP), WS), NBITS, FUNCS, CNAME) INSTRS, .K)

--- a/tests/evm-to-iele/iele.ml
+++ b/tests/evm-to-iele/iele.ml
@@ -192,6 +192,18 @@ let asm_iele ops =
   | VoidOp(`REGISTERS n,[]) :: tail -> n
   | _ -> 5
   in
-  let buf = Buffer.create ((List.length ops) * 2) in
-  asm_iele_aux ops buf nregs;
-  Buffer.contents buf
+  let int_to_bytes i =
+    assert(i >= 0 && i < 4294967296);
+    let nth_byte_be n = char_of_int ((i lsr ((3 - n) * 8)) land 0xff) in
+    Bytes.init 4 nth_byte_be
+  in
+  let bytes_buf = Buffer.create ((List.length ops) * 2) in
+  asm_iele_aux ops bytes_buf nregs;
+  let bytes_length = Buffer.length bytes_buf in
+  if bytes_length = 0 then
+    ""
+  else
+    let buf = Buffer.create (bytes_length + 4) in
+    Buffer.add_bytes buf (int_to_bytes bytes_length);
+    Buffer.add_buffer buf bytes_buf;
+    Buffer.contents buf

--- a/tests/evm-to-iele/iele.ml
+++ b/tests/evm-to-iele/iele.ml
@@ -192,18 +192,11 @@ let asm_iele ops =
   | VoidOp(`REGISTERS n,[]) :: tail -> n
   | _ -> 5
   in
-  let int_to_bytes i =
-    assert(i >= 0 && i < 4294967296);
-    let nth_byte_be n = char_of_int ((i lsr ((3 - n) * 8)) land 0xff) in
-    Bytes.init 4 nth_byte_be
-  in
-  let bytes_buf = Buffer.create ((List.length ops) * 2) in
-  asm_iele_aux ops bytes_buf nregs;
-  let bytes_length = Buffer.length bytes_buf in
+  let buf = Buffer.create ((List.length ops) * 2) in
+  asm_iele_aux ops buf nregs;
+  let bytes_length = Buffer.length buf in
   if bytes_length = 0 then
     ""
   else
-    let buf = Buffer.create (bytes_length + 4) in
-    Buffer.add_bytes buf (int_to_bytes bytes_length);
-    Buffer.add_buffer buf bytes_buf;
-    Buffer.contents buf
+    let size_header = IeleUtil.be_int_width (Z.of_int bytes_length) 32 in
+    size_header ^ Buffer.contents buf

--- a/tests/iele/ERC20/create.iele.json
+++ b/tests/iele/ERC20/create.iele.json
@@ -14,7 +14,7 @@
                     {
                         "out": ["0x6295ee1b4f6dd65047762f924ecd367c17eabf8f"],
                         "status": "",
-                        "gas": "0x0c682c",
+                        "gas": "0x0c647c",
                         "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
                         "refund": ""
                     }

--- a/tests/iele/auction/create.iele.json
+++ b/tests/iele/auction/create.iele.json
@@ -14,7 +14,7 @@
                     {
                         "out": ["0x6295ee1b4f6dd65047762f924ecd367c17eabf8f"],
                         "status": "",
-                        "gas": "0x0db18c",
+                        "gas": "0x0daddc",
                         "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
                         "refund": ""
                     }

--- a/tests/iele/forwarder/copycreate.iele.json
+++ b/tests/iele/forwarder/copycreate.iele.json
@@ -14,14 +14,14 @@
                     {
                         "out": ["0x6295ee1b4f6dd65047762f924ecd367c17eabf8f"],
                         "status": "",
-                        "gas": "0x0ecf63",
+                        "gas": "0x0ecbf3",
                         "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
                         "refund": ""
                     },
                     {
                         "out": ["0xec0e71ad0a90ffe1909d27dac207f7680abba42d"],
                         "status": "",
-                        "gas": "0x0e46f6",
+                        "gas": "0x0e4386",
                         "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
                         "refund": ""
                     },

--- a/tests/iele/forwarder/create.iele.json
+++ b/tests/iele/forwarder/create.iele.json
@@ -14,7 +14,7 @@
                     {
                         "out": ["0x6295ee1b4f6dd65047762f924ecd367c17eabf8f"],
                         "status": "",
-                        "gas": "0x0e4415",
+                        "gas": "0x0e3d35",
                         "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
                         "refund": ""
                     },

--- a/tests/iele/ill-formed/illFormed.iele.json
+++ b/tests/iele/ill-formed/illFormed.iele.json
@@ -14,7 +14,7 @@
                     {
                         "out": [],
                         "status": "0x09",
-                        "gas": "0x0f2fe4",
+                        "gas": "0x0f2f94",
                         "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
                         "refund": ""
                     }


### PR DESCRIPTION
This PR adds a new opcode in the binary format (0x6b) that signifies start of a metadata stamp. The metadata stamp is a binary string of arbitrary length and contents that is being dropped from the IELE disassembler at loading time. I didn't include this opcode in the assembler since there is no way to add a metadata stamp to a textual iele program.