### PR TITLE
Binary contract validator

### DIFF
--- a/compiler/src/IeleAssembler.hs
+++ b/compiler/src/IeleAssembler.hs
@@ -112,8 +112,8 @@ asm_iele_opcode_call :: IeleOpcodeCall Word16 Word16 -> Put
 asm_iele_opcode_call opCall = case opCall of
   CALL call nargs nreturn -> putWord8 0xf2 >> putWord16be call >> putArgs16 nargs >> putRets16 nreturn
   CALLDYN nargs nreturn -> putWord8 0xf3 >> putArgs16 nargs >> putRets16 nreturn
-  STATICCALL call nargs nreturn -> putWord8 0xf5 >> putWord16be call >> putArgs16 nargs >> putRets16 nreturn
-  STATICCALLDYN nargs nreturn -> putWord8 0xf4 >> putArgs16 nargs >> putRets16 nreturn
+  STATICCALL call nargs nreturn -> putWord8 0xf4 >> putWord16be call >> putArgs16 nargs >> putRets16 nreturn
+  STATICCALLDYN nargs nreturn -> putWord8 0xf5 >> putArgs16 nargs >> putRets16 nreturn
   LOCALCALL call nargs nreturn -> putWord8 0xf8 >> putWord16be call >> putArgs16 nargs >> putRets16 nreturn
   LOCALCALLDYN nargs nreturn -> putWord8 0xf9 >> putArgs16 nargs >> putRets16 nreturn
   CALLADDRESS call -> putWord8 0xfa >> putWord16be call

--- a/compiler/src/IeleAssembler.hs
+++ b/compiler/src/IeleAssembler.hs
@@ -156,7 +156,7 @@ asm_iele_op nregs op = case op of
   VoidOp opcode regs -> asm_iele_opcode0 opcode >> enc_regs regs
   CallOp opcode regs1 regs2 -> asm_iele_opcode_call opcode >> enc_regs (regs1++regs2)
   LiOp opcode r payload ->
-    do asm_iele_opcode_li opcode; enc_regs [r]; rlp_put_bytes (be_bytes payload)
+    do asm_iele_opcode_li opcode; rlp_put_bytes (be_bytes payload); enc_regs [r]
  where enc_regs all_regs = asm_iele_regs nregs all_regs
 
 asm_iele :: Putter [IeleOp]

--- a/compiler/src/IeleAssembler.hs
+++ b/compiler/src/IeleAssembler.hs
@@ -98,10 +98,9 @@ asm_iele_opcode0 op0 = case op0 of
         | otherwise -> error "LOG only takes up to 4 values"
 
   RETURN nargs -> putWord8 0xf6 >> putArgs16 nargs
-  REVERT nargs -> putWord8 0xf7 >> putArgs16 nargs
 
+  REVERT -> putWord8 0xf7
   INVALID -> putWord8 0xfe
-
   SELFDESTRUCT -> putWord8 0xff
 
 asm_iele_opcode_li :: IeleOpcodeLi -> Put

--- a/compiler/src/IeleInstructions.hs
+++ b/compiler/src/IeleInstructions.hs
@@ -140,8 +140,8 @@ data IeleOpcode0G funId lblId =
  | LOG Word8
 
  | RETURN (Args Word16)
- | REVERT (Args Word16)
 
+ | REVERT
  | INVALID
  | SELFDESTRUCT
   deriving (Show, Eq, Data)
@@ -171,8 +171,8 @@ retypeOpcode0 fun lbl i = case i of
    LOG arity -> pure (LOG arity)
 
    RETURN arity -> pure (RETURN arity)
-   REVERT arity -> pure (REVERT arity)
 
+   REVERT -> pure (REVERT)
    INVALID -> pure (INVALID)
    SELFDESTRUCT -> pure (SELFDESTRUCT)
 

--- a/compiler/src/IeleParserImplementation.hs
+++ b/compiler/src/IeleParserImplementation.hs
@@ -487,7 +487,7 @@ returnInst = skipKeyword "ret" *>
   fmap (\args -> VoidOp (RETURN (argsLength args)) args) argumentsOrVoid
 
 revertInst :: Parser IeleOpP
-revertInst = simpleOp0 "revert" 1 (REVERT (mkArgs 1))
+revertInst = simpleOp0 "revert" 1 (REVERT)
 
 selfDestructInst :: Parser IeleOpP
 selfDestructInst = simpleOp0 "selfdestruct" 1 SELFDESTRUCT

--- a/compiler/src/IelePrint.hs
+++ b/compiler/src/IelePrint.hs
@@ -251,9 +251,7 @@ prettyVoidOp op args = case op of
     [reg] -> prettyCondJump reg lbl
     _ -> error "conditional jump takes exactly one register argument"
   RETURN _ -> prettyReturn args
-  REVERT _ -> case args of
-    [arg] -> text "revert" <+> arg
-    _ -> error "revert takes exactly one argument"
+  REVERT -> simple "revert"
   INVALID -> text "call @iele.invalid(" <> commaList args <> char ')'
   SSTORE -> simple "sstore"
   MSTORE -> simple "store"

--- a/ethereum.md
+++ b/ethereum.md
@@ -115,7 +115,7 @@ To do so, we'll extend sort `JSON` with some IELE specific syntax, and provide a
           => #fun(CONTRACT =>
              #checkContract CONTRACT
           ~> #create ACCTFROM #newAddr(ACCTFROM, NONCE) (GLIMIT -Int G0(SCHED, CODE, ARGS)) VALUE CONTRACT ARGS
-          ~> #codeDeposit #newAddr(ACCTFROM, NONCE) #sizeWordStack(CODE) CONTRACT %0 %1 true ~> #adjustGas ~> #finalizeTx(false) ~> startTx)(#dasmContract(CODE, Main))
+          ~> #codeDeposit #newAddr(ACCTFROM, NONCE) #sizeWordStack(CODE) CONTRACT %0 %1 true ~> #adjustGas ~> #finalizeTx(false) ~> startTx)(#if #isValidContract(CODE) #then #dasmContract(CODE, Main) #else #illFormed #fi)
          ...
          </k>
          <schedule> SCHED </schedule>

--- a/iele-binary.md
+++ b/iele-binary.md
@@ -42,6 +42,7 @@ contains enough information to determine and decode the rest of the operation.
                     | MSIZE ()
                     | SELFDESTRUCT ()
                     | LOG0 ()
+                    | REVERT()
 
     syntax BinOp ::= ISZERO ()
                    | NOT ()
@@ -99,7 +100,6 @@ contains enough information to determine and decode the rest of the operation.
                     | CALLADDRESS ( Int )
 
     syntax ReturnOp ::= RETURN ( Int )
-                      | REVERT ( Int )
 
     syntax LocalCallOp ::= LOCALCALL ( Int , Int , Int )
                          | LOCALCALLDYN ( Int , Int )
@@ -294,7 +294,7 @@ After interpreting the strings representing programs as a `WordStack`, it should
     rule #dasmInstruction ( CREATE (LABEL, ARGS), R, W, M, _, NAME ) => %(R, W, M, 0) , %(R, W, M, 1) = create NAME +.+IeleName {#parseToken("IeleName", Int2String(LABEL))}:>IeleName ( %o(R, W, M, 3, ARGS) ) send %(R, W, M, 2)
     rule #dasmInstruction ( COPYCREATE (ARGS), R, W, M, _, _ ) => %(R, W, M, 0) , %(R, W, M, 1) = copycreate %(R, W, M, 3) ( %o(R, W, M, 4, ARGS) ) send %(R, W, M, 2)
 
-    rule #dasmInstruction ( REVERT(1), R, W, M, _, _ ) => revert %(R, W, M, 0)
+    rule #dasmInstruction ( REVERT(), R, W, M, _, _ ) => revert %(R, W, M, 0)
     rule #dasmInstruction ( RETURN(RETS), R, W, M, _, _ ) => ret %o(R, W, M, 0, RETS)
       requires RETS =/=Int 0
     rule #dasmInstruction ( RETURN(0), R, W, M, _, _ ) => ret void
@@ -327,7 +327,6 @@ After interpreting the strings representing programs as a `WordStack`, it should
     rule #opCodeWidth( LOCALCALL(_,_,_) )   => 7
     rule #opCodeWidth( LOCALCALLDYN(_,_) )  => 5
     rule #opCodeWidth( RETURN(_) )          => 3
-    rule #opCodeWidth( REVERT(_) )          => 3
     rule #opCodeWidth( CALL(_,_,_) )        => 7
     rule #opCodeWidth( CALLDYN(_,_) )       => 5
     rule #opCodeWidth( STATICCALL(_,_,_) )  => 7
@@ -353,7 +352,6 @@ After interpreting the strings representing programs as a `WordStack`, it should
     rule #numArgs ( LOCALCALLDYN (   ARGS, RETS) ) => 1 +Int ARGS +Int RETS
     rule #numArgs ( CALLADDRESS(_) )               => 2
     rule #numArgs ( RETURN(RETS) )                 => RETS
-    rule #numArgs ( REVERT(RETS) )                 => RETS
     rule #numArgs ( CREATE(_, ARGS) )              => 3 +Int ARGS
     rule #numArgs ( COPYCREATE(ARGS) )             => 4 +Int ARGS
 

--- a/iele-binary.md
+++ b/iele-binary.md
@@ -133,17 +133,17 @@ After interpreting the strings representing programs as a `WordStack`, it should
  // ----------------------------------------------------------------------------------------------------------------------------------------------------
     rule #dasmContract( .WordStack, NAME) => #emptyCode
     rule #dasmContract( W1 : W2 : W3 : W4 : 99 : WS, NAME) => #dasmContract(99 : #take( W1 *Int 16777216  +Int W2 *Int 65536 +Int W3 *Int 256 +Int W4 -Int 1, WS), NAME, W1 : W2 : W3 : W4 : .WordStack)
-      requires #isValidContract(W1 : W2 : W3 : W4 : 99 : WS, #sizeWordStack(WS) +Int 5)
-    rule #dasmContract(_, _) => #illFormed [owise]
 
     rule #dasmContract( 99 : NBITS : WS, NAME, W1 : W2 : W3 : W4 : .WordStack ) => #dasmContract(WS, NBITS, 0 |-> init, NAME, .TopLevelDefinitions, 1, #sizeWordStack(WS) +Int 6 , #unparseByteStack(W1 : W2 : W3 : W4 : 99 : NBITS : WS))
     rule #dasmContract( 105 : W1 : W2 : WS, NBITS, FUNCS, NAME, DEFS, N, SIZE, BYTES ) => #dasmContract(#drop(W1 *Int 256 +Int W2, WS), NBITS, N |-> #parseToken("IeleName", #unparseByteStack(#take(W1 *Int 256 +Int W2, WS))) FUNCS, NAME, DEFS, N +Int 1, SIZE, BYTES )
     rule #dasmContract( 106 : W1 : W2 : WS, NBITS, FUNCS, NAME, DEFS, N, SIZE, BYTES ) => #dasmContract(#take(W1 *Int 256 +Int W2, WS), NAME +.+IeleName N) ++Contract #dasmContract(#drop(W1 *Int 256 +Int W2, WS), NBITS, FUNCS, NAME, external contract NAME +.+IeleName N DEFS, N +Int 1, SIZE, BYTES)
     rule #dasmContract( WS, NBITS, FUNCS, NAME, DEFS, N, SIZE, BYTES ) => contract NAME ! SIZE BYTES { DEFS ++TopLevelDefinitions #dasmFunctions(WS, NBITS, FUNCS, NAME) } .Contract [owise]
 
-    syntax Bool ::= #isValidContract(WordStack, Int)         [function]
+    syntax Bool ::= #isValidContract(WordStack)              [function]
+                  | #isValidContract(WordStack, Int)         [function, klabel(isValidContractAux)]
                   | #isValidStringTable(WordStack, Int, Int) [function]
  // -------------------------------------------------------------------
+    rule #isValidContract(CODE) => #isValidContract(CODE, #sizeWordStack(CODE))
     rule #isValidContract(.WordStack, 0) => true
     rule #isValidContract(W1 : W2 : W3 : W4 : 99 : NBITS : WS, SIZE) => #fun(DECLSIZE => SIZE -Int 4 >=Int DECLSIZE andBool #isValidStringTable(#take(DECLSIZE -Int 2, WS), NBITS, DECLSIZE -Int 2))(W1 *Int 16777216 +Int W2 *Int 65536 +Int W3 *Int 256 +Int W4)
     rule #isValidContract(_, _) => false [owise]

--- a/iele-binary.md
+++ b/iele-binary.md
@@ -20,13 +20,13 @@ contains enough information to determine and decode the rest of the operation.
 
 ```k
 
-    syntax NullOp ::= LOADPOS ( Int , Int )
-                    | LOADNEG ( Int , Int )
-                    | BRLABEL ( Int )
+    syntax NullOp ::= BRLABEL ( Int )
                     | BR ( Int )
                     | INVALID ()
 
-    syntax UnOp   ::= BRC ( Int )
+    syntax UnOp   ::= LOADPOS ( Int , Int )
+                    | LOADNEG ( Int , Int )
+                    | BRC ( Int )
                     | GASLIMIT ()
                     | GASPRICE ()
                     | GAS ()
@@ -315,8 +315,6 @@ After interpreting the strings representing programs as a `WordStack`, it should
 
     syntax Int ::= #opWidth ( OpCode , Int ) [function]
  // ---------------------------------------------------
-    rule #opWidth ( LOADPOS(N, _), NBITS ) => 1 +Int N +Int (NBITS up/Int 8)
-    rule #opWidth ( LOADNEG(N, _), NBITS ) => 1 +Int N +Int (NBITS up/Int 8)
     rule #opWidth ( OP, NBITS ) => #opCodeWidth(OP) +Int ((NBITS *Int #numArgs(OP)) up/Int 8) [owise]
 
     syntax Int ::= #opCodeWidth ( OpCode ) [function]
@@ -334,6 +332,8 @@ After interpreting the strings representing programs as a `WordStack`, it should
     rule #opCodeWidth( CALLADDRESS(_) )     => 3
     rule #opCodeWidth( _:CreateOp )         => 5
     rule #opCodeWidth( _:CopyCreateOp )     => 3
+    rule #opCodeWidth ( LOADPOS(N, _) )     => 1 +Int N
+    rule #opCodeWidth ( LOADNEG(N, _) )     => 1 +Int N
     rule #opCodeWidth( OP )                 => 1 [owise]
 
     syntax Int ::= #numArgs ( OpCode ) [function]

--- a/iele-binary.md
+++ b/iele-binary.md
@@ -186,7 +186,7 @@ After interpreting the strings representing programs as a `WordStack`, it should
     rule #isValidFunction(W : WS, NBITS, SIZE) => #isValidFunctions(W : WS, NBITS, SIZE)
       requires W ==Int 103 orBool W ==Int 104
     rule #isValidFunction(.WordStack, _, 0) => true
-    rule #isValidFunction(W : WS, NBITS, SIZE) => #isValidLoad(WS, SIZE -Int 1) andBool #isValidInstruction(#dasmOpCode(WS), WS, NBITS, SIZE)
+    rule #isValidFunction(W : WS, NBITS, SIZE) => #isValidLoad(WS, SIZE -Int 1) andBool #isValidInstruction(#dasmOpCode(W : WS), W : WS, NBITS, SIZE)
       requires W ==Int 97 orBool W ==Int 98
     rule #isValidFunction(WS, NBITS, SIZE) => #isValidInstruction(#dasmOpCode(WS), WS, NBITS, SIZE) [owise]
 

--- a/iele-binary.md
+++ b/iele-binary.md
@@ -131,7 +131,7 @@ After interpreting the strings representing programs as a `WordStack`, it should
                       | #dasmContract ( WordStack , IeleName , WordStack ) [function, klabel(#dasmContractAux1)]
                       | #dasmContract ( WordStack , Int , Map, IeleName , TopLevelDefinitions, Int , Int , String ) [function, klabel(#dasmContractAux2)]
  // ----------------------------------------------------------------------------------------------------------------------------------------------------
-    rule #dasmContract( .WordStack, NAME) => #emptyCode
+    rule #dasmContract( .WordStack, _) => #emptyCode
     rule #dasmContract( W1 : W2 : W3 : W4 : 99 : WS, NAME) => #dasmContract(99 : #take( W1 *Int 16777216  +Int W2 *Int 65536 +Int W3 *Int 256 +Int W4 -Int 1, WS), NAME, W1 : W2 : W3 : W4 : .WordStack)
 
     rule #dasmContract( 99 : NBITS : WS, NAME, W1 : W2 : W3 : W4 : .WordStack ) => #dasmContract(WS, NBITS, 0 |-> init, NAME, .TopLevelDefinitions, 1, #sizeWordStack(WS) +Int 6 , #unparseByteStack(W1 : W2 : W3 : W4 : 99 : NBITS : WS))

--- a/iele-binary.md
+++ b/iele-binary.md
@@ -115,7 +115,7 @@ contains enough information to determine and decode the rest of the operation.
                     | QuadOp
                     | BinOp
                     | FiveOp
-
+                    | encodingError()
 ```
 
 After interpreting the strings representing programs as a `WordStack`, it should be changed into a `Contract` for use by the IELE semantics.
@@ -131,12 +131,28 @@ After interpreting the strings representing programs as a `WordStack`, it should
                       | #dasmContract ( WordStack , IeleName , WordStack ) [function, klabel(#dasmContractAux1)]
                       | #dasmContract ( WordStack , Int , Map, IeleName , TopLevelDefinitions, Int , Int , String ) [function, klabel(#dasmContractAux2)]
  // ----------------------------------------------------------------------------------------------------------------------------------------------------
-    rule #dasmContract( .WordStack, _) => #emptyCode
+    rule #dasmContract( .WordStack, NAME) => #emptyCode
     rule #dasmContract( W1 : W2 : W3 : W4 : 99 : WS, NAME) => #dasmContract(99 : #take( W1 *Int 16777216  +Int W2 *Int 65536 +Int W3 *Int 256 +Int W4 -Int 1, WS), NAME, W1 : W2 : W3 : W4 : .WordStack)
+      requires #isValidContract(W1 : W2 : W3 : W4 : 99 : WS, #sizeWordStack(WS) +Int 5)
+    rule #dasmContract(_, _) => #illFormed [owise]
+
     rule #dasmContract( 99 : NBITS : WS, NAME, W1 : W2 : W3 : W4 : .WordStack ) => #dasmContract(WS, NBITS, 0 |-> init, NAME, .TopLevelDefinitions, 1, #sizeWordStack(WS) +Int 6 , #unparseByteStack(W1 : W2 : W3 : W4 : 99 : NBITS : WS))
     rule #dasmContract( 105 : W1 : W2 : WS, NBITS, FUNCS, NAME, DEFS, N, SIZE, BYTES ) => #dasmContract(#drop(W1 *Int 256 +Int W2, WS), NBITS, N |-> #parseToken("IeleName", #unparseByteStack(#take(W1 *Int 256 +Int W2, WS))) FUNCS, NAME, DEFS, N +Int 1, SIZE, BYTES )
     rule #dasmContract( 106 : W1 : W2 : WS, NBITS, FUNCS, NAME, DEFS, N, SIZE, BYTES ) => #dasmContract(#take(W1 *Int 256 +Int W2, WS), NAME +.+IeleName N) ++Contract #dasmContract(#drop(W1 *Int 256 +Int W2, WS), NBITS, FUNCS, NAME, external contract NAME +.+IeleName N DEFS, N +Int 1, SIZE, BYTES)
     rule #dasmContract( WS, NBITS, FUNCS, NAME, DEFS, N, SIZE, BYTES ) => contract NAME ! SIZE BYTES { DEFS ++TopLevelDefinitions #dasmFunctions(WS, NBITS, FUNCS, NAME) } .Contract [owise]
+
+    syntax Bool ::= #isValidContract(WordStack, Int)         [function]
+                  | #isValidStringTable(WordStack, Int, Int) [function]
+ // -------------------------------------------------------------------
+    rule #isValidContract(.WordStack, 0) => true
+    rule #isValidContract(W1 : W2 : W3 : W4 : 99 : NBITS : WS, SIZE) => #fun(DECLSIZE => SIZE -Int 4 >=Int DECLSIZE andBool #isValidStringTable(#take(DECLSIZE -Int 2, WS), NBITS, DECLSIZE -Int 2))(W1 *Int 16777216 +Int W2 *Int 65536 +Int W3 *Int 256 +Int W4)
+    rule #isValidContract(_, _) => false [owise]
+
+    rule #isValidStringTable(105 : W1 : W2 : WS, NBITS, SIZE) => SIZE -Int 3 >=Int W1 *Int 256 +Int W2 andBool #isValidStringTable(#drop(W1 *Int 256 +Int W2, WS), NBITS, SIZE -Int 3 -Int W1 *Int 256 -Int W2)
+    rule #isValidStringTable(106 : W1 : W2 : WS, NBITS, SIZE) => SIZE -Int 3 >=Int W1 *Int 256 +Int W2 andBool #isValidContract(#take(W1 *Int 256 +Int W2, WS), W1 *Int 256 +Int W2) andBool #isValidStringTable(#drop(W1 *Int 256 +Int W2, WS), NBITS, SIZE -Int 3 -Int W1 *Int 256 -Int W2)
+      requires W1 =/=Int 0 orBool W2 =/=Int 0
+    rule #isValidStringTable(106 : 0 : 0 : WS, NBITS, SIZE) => false
+    rule #isValidStringTable(WS, NBITS, SIZE) => #isValidFunctions(WS, NBITS, SIZE) [owise]
 
     syntax priorities contractDefinitionList > contractAppend
     syntax priorities topLevelDefinitionList > topLevelAppend
@@ -157,6 +173,28 @@ After interpreting the strings representing programs as a `WordStack`, it should
     rule #dasmFunctions(104 : W1 : W2 : W3 : W4 : WS, NBITS, FUNCS, NAME) => #dasmFunction(true, {FUNCS [ W1 *Int 256 +Int W2 ] orDefault W1 *Int 256 +Int W2}:>IeleName, NAME, W3 *Int 256 +Int W4, WS, NBITS, FUNCS, .Instructions, .K)
     rule #dasmFunctions(.WordStack, NBITS, FUNCS, NAME) => .TopLevelDefinitions
 
+    syntax Bool ::= #isValidFunctions(WordStack, Int, Int)           [function]
+                  | #isValidFunction(WordStack, Int, Int)            [function]
+                  | #isValidInstruction(OpCode, WordStack, Int, Int) [function]
+                  | #isValidLoad(WordStack, Int)                     [function]
+ // ---------------------------------------------------------------------------
+    rule #isValidFunctions(103 : W1 : W2 : W3 : W4 : WS, NBITS, SIZE) => #isValidFunction(WS, NBITS, SIZE -Int 5)
+    rule #isValidFunctions(104 : W1 : W2 : W3 : W4 : WS, NBITS, SIZE) => #isValidFunction(WS, NBITS, SIZE -Int 5)
+    rule #isValidFunctions(.WordStack, _, 0) => true
+    rule #isValidFunctions(_, _, _) => false [owise]
+
+    rule #isValidFunction(W : WS, NBITS, SIZE) => #isValidFunctions(W : WS, NBITS, SIZE)
+      requires W ==Int 103 orBool W ==Int 104
+    rule #isValidFunction(.WordStack, _, 0) => true
+    rule #isValidFunction(W : WS, NBITS, SIZE) => #isValidLoad(WS, SIZE -Int 1) andBool #isValidInstruction(#dasmOpCode(WS), WS, NBITS, SIZE)
+      requires W ==Int 97 orBool W ==Int 98
+    rule #isValidFunction(WS, NBITS, SIZE) => #isValidInstruction(#dasmOpCode(WS), WS, NBITS, SIZE) [owise]
+
+    rule #isValidInstruction(encodingError(), _, _, _) => false
+    rule #isValidInstruction(OP:OpCode, WS, NBITS, SIZE) => SIZE >=Int #opWidth(OP, NBITS) andBool #isValidFunction(#drop(#opWidth(OP, NBITS), WS), NBITS, SIZE -Int #opWidth(OP, NBITS)) [owise]
+
+    rule #isValidLoad(WS, SIZE) => SIZE >=Int #loadLen(WS) +Int #loadOffset(WS)
+
     rule #dasmFunction(false, NAME, CNAME, SIG, W : WS, NBITS, FUNCS, INSTRS, .K) => define @ NAME ( SIG ) { #toBlocks(INSTRS) } #dasmFunctions(W : WS, NBITS, FUNCS, CNAME)
       requires W ==Int 103 orBool W ==Int 104
     rule #dasmFunction(true, NAME, CNAME, SIG, W : WS, NBITS, FUNCS, INSTRS, .K) => define public @ NAME ( SIG ) { #toBlocks(INSTRS) } #dasmFunctions(W : WS, NBITS, FUNCS, CNAME)
@@ -164,32 +202,9 @@ After interpreting the strings representing programs as a `WordStack`, it should
     rule #dasmFunction(false, NAME, CNAME, SIG, .WordStack, NBITS, FUNCS, INSTRS, .K) => define @ NAME ( SIG ) { #toBlocks(INSTRS) } .TopLevelDefinitions
     rule #dasmFunction(true, NAME, CNAME, SIG, .WordStack, NBITS, FUNCS, INSTRS, .K) => define public @ NAME ( SIG ) { #toBlocks(INSTRS) } .TopLevelDefinitions
 
-    rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, W : WS, NBITS, FUNCS, INSTRS, .K) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, #dasmOpCode(W))
-      requires (W >=Int 0   andBool W <=Int 96)
-        orBool (W >=Int 107 andBool W <=Int 239)
-        orBool (W >=Int 251 andBool W <=Int 255)
+    rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, .K) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, #dasmOpCode(WS)) [owise]
 
-    rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, OP:OpCode) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, #drop(#opWidth(OP, NBITS) -Int #opCodeWidth(OP), WS), NBITS, FUNCS, #dasmInstruction(OP, #take(#opWidth(OP, NBITS) -Int #opCodeWidth(OP), WS), NBITS, FUNCS, CNAME) INSTRS, .K)
-
-    rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, W : WS, NBITS, FUNCS, INSTRS, .K) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, W : WS, NBITS, FUNCS, INSTRS, #str(#loadLen(#drop(NBITS up/Int 8, WS)), #loadOffset(#drop(NBITS up/Int 8, WS))))
-      requires W >=Int 97 andBool W <Int 99
-    rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, 97  : WS, NBITS, FUNCS, INSTRS, #str(LEN, POS)) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, LOADPOS(LEN +Int POS, #asUnsigned(WS [ POS +Int (NBITS up/Int 8) .. LEN ])))
-    rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, 98  : WS, NBITS, FUNCS, INSTRS, #str(LEN, POS)) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, LOADNEG(LEN +Int POS, #asUnsigned(WS [ POS +Int (NBITS up/Int 8) .. LEN ])))
-
-    rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, 100 : W1 : W2 : WS, NBITS, FUNCS, INSTRS, .K) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, BR(W1 *Int 256 +Int W2))
-    rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, 101 : W1 : W2 : WS, NBITS, FUNCS, INSTRS, .K) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, BRC(W1 *Int 256 +Int W2))
-    rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, 102 : W1 : W2 : WS, NBITS, FUNCS, INSTRS, .K) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, BRLABEL(W1 *Int 256 +Int W2))
-    rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, 241 : W1 : W2 : WS, NBITS, FUNCS, INSTRS, .K) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, COPYCREATE(W1 *Int 256 +Int W2))
-    rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, 246 : W1 : W2 : WS, NBITS, FUNCS, INSTRS, .K) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, RETURN(W1 *Int 256 +Int W2))
-    rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, 247 : W1 : W2 : WS, NBITS, FUNCS, INSTRS, .K) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, REVERT(W1 *Int 256 +Int W2))
-    rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, 240 : W1 : W2 : W3 : W4 : WS, NBITS, FUNCS, INSTRS, .K) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, CREATE(W1 *Int 256 +Int W2, W3 *Int 256 +Int W4))
-    rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, 242 : W1 : W2 : W3 : W4 : W5 : W6 : WS, NBITS, FUNCS, INSTRS, .K) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, CALL(W1 *Int 256 +Int W2, W3 *Int 256 +Int W4, W5 *Int 256 +Int W6))
-    rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, 243 : W1 : W2 : W3 : W4 : WS, NBITS, FUNCS, INSTRS, .K) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, CALLDYN(W1 *Int 256 +Int W2, W3 *Int 256 +Int W4))
-    rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, 245 : W1 : W2 : W3 : W4 : W5 : W6 : WS, NBITS, FUNCS, INSTRS, .K) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, STATICCALL(W1 *Int 256 +Int W2, W3 *Int 256 +Int W4, W5 *Int 256 +Int W6))
-    rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, 244 : W1 : W2 : W3 : W4 : WS, NBITS, FUNCS, INSTRS, .K) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, STATICCALLDYN(W1 *Int 256 +Int W2, W3 *Int 256 +Int W4))
-    rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, 248 : W1 : W2 : W3 : W4 : W5 : W6 : WS, NBITS, FUNCS, INSTRS, .K) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, LOCALCALL(W1 *Int 256 +Int W2, W3 *Int 256 +Int W4, W5 *Int 256 +Int W6))
-    rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, 249 : W1 : W2 : W3 : W4 : WS, NBITS, FUNCS, INSTRS, .K) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, LOCALCALLDYN(W1 *Int 256 +Int W2, W3 *Int 256 +Int W4))
-    rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, 250 : W1 : W2 : WS, NBITS, FUNCS, INSTRS, .K) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, CALLADDRESS(W1 *Int 256 +Int W2))
+    rule #dasmFunction(PUBLIC, NAME, CNAME, SIG, WS, NBITS, FUNCS, INSTRS, OP:OpCode) => #dasmFunction(PUBLIC, NAME, CNAME, SIG, #drop(#opWidth(OP, NBITS), WS), NBITS, FUNCS, #dasmInstruction(OP, #take(#opWidth(OP, NBITS) -Int #opCodeWidth(OP), #drop(#opCodeWidth(OP), WS)), NBITS, FUNCS, CNAME) INSTRS, .K)
 
     syntax Blocks ::= #toBlocks ( Instructions ) [function]
                     | #toBlocks ( Instructions , Blocks ) [function, klabel(#toBlockAux)]
@@ -355,66 +370,87 @@ After interpreting the strings representing programs as a `WordStack`, it should
     rule #numArgs ( CREATE(_, ARGS) )              => 3 +Int ARGS
     rule #numArgs ( COPYCREATE(ARGS) )             => 4 +Int ARGS
 
-    syntax OpCode ::= #dasmOpCode ( Int ) [function]
- // ------------------------------------------------
-    rule #dasmOpCode(   1 ) => ADD ()
-    rule #dasmOpCode(   2 ) => MUL ()
-    rule #dasmOpCode(   3 ) => SUB ()
-    rule #dasmOpCode(   4 ) => DIV ()
-    rule #dasmOpCode(   6 ) => MOD ()
-    rule #dasmOpCode(   7 ) => EXP ()
-    rule #dasmOpCode(   8 ) => ADDMOD ()
-    rule #dasmOpCode(   9 ) => MULMOD ()
-    rule #dasmOpCode(  10 ) => EXPMOD ()
-    rule #dasmOpCode(  11 ) => SIGNEXTEND ()
-    rule #dasmOpCode(  12 ) => TWOS ()
-    rule #dasmOpCode(  13 ) => BSWAP ()
-    rule #dasmOpCode(  15 ) => NE ()
-    rule #dasmOpCode(  16 ) => LT ()
-    rule #dasmOpCode(  17 ) => GT ()
-    rule #dasmOpCode(  18 ) => LE ()
-    rule #dasmOpCode(  19 ) => GE ()
-    rule #dasmOpCode(  20 ) => EQ ()
-    rule #dasmOpCode(  21 ) => ISZERO ()
-    rule #dasmOpCode(  22 ) => AND ()
-    rule #dasmOpCode(  23 ) => OR ()
-    rule #dasmOpCode(  24 ) => XOR ()
-    rule #dasmOpCode(  25 ) => NOT ()
-    rule #dasmOpCode(  26 ) => BYTE ()
-    rule #dasmOpCode(  27 ) => SHIFT ()
-    rule #dasmOpCode(  28 ) => LOGARITHM2 ()
-    rule #dasmOpCode(  32 ) => SHA3 ()
-    rule #dasmOpCode(  48 ) => ADDRESS ()
-    rule #dasmOpCode(  49 ) => BALANCE ()
-    rule #dasmOpCode(  50 ) => ORIGIN ()
-    rule #dasmOpCode(  51 ) => CALLER ()
-    rule #dasmOpCode(  52 ) => CALLVALUE ()
-    rule #dasmOpCode(  56 ) => CODESIZE ()
-    rule #dasmOpCode(  58 ) => GASPRICE ()
-    rule #dasmOpCode(  59 ) => EXTCODESIZE ()
-    rule #dasmOpCode(  64 ) => BLOCKHASH ()
-    rule #dasmOpCode(  65 ) => BENEFICIARY ()
-    rule #dasmOpCode(  66 ) => TIMESTAMP ()
-    rule #dasmOpCode(  67 ) => NUMBER ()
-    rule #dasmOpCode(  68 ) => DIFFICULTY ()
-    rule #dasmOpCode(  69 ) => GASLIMIT ()
-    rule #dasmOpCode(  80 ) => MLOADN ()
-    rule #dasmOpCode(  81 ) => MLOAD ()
-    rule #dasmOpCode(  82 ) => MSTOREN ()
-    rule #dasmOpCode(  83 ) => MSTORE ()
-    rule #dasmOpCode(  84 ) => SLOAD ()
-    rule #dasmOpCode(  85 ) => SSTORE ()
-    rule #dasmOpCode(  86 ) => MSIZE ()
-    rule #dasmOpCode(  87 ) => GAS ()
-    rule #dasmOpCode(  96 ) => MOVE ()
-    rule #dasmOpCode( 160 ) => LOG0 ()
-    rule #dasmOpCode( 161 ) => LOG1 ()
-    rule #dasmOpCode( 162 ) => LOG2 ()
-    rule #dasmOpCode( 163 ) => LOG3 ()
-    rule #dasmOpCode( 164 ) => LOG4 ()
-    rule #dasmOpCode( 255 ) => SELFDESTRUCT ()
-    rule #dasmOpCode(   W ) => INVALID () [owise]
+    syntax OpCode ::= #dasmOpCode ( WordStack ) [function]
+ // ------------------------------------------------------
+    rule #dasmOpCode(   1 :  _ ) => ADD ()
+    rule #dasmOpCode(   2 :  _ ) => MUL ()
+    rule #dasmOpCode(   3 :  _ ) => SUB ()
+    rule #dasmOpCode(   4 :  _ ) => DIV ()
+    rule #dasmOpCode(   6 :  _ ) => MOD ()
+    rule #dasmOpCode(   7 :  _ ) => EXP ()
+    rule #dasmOpCode(   8 :  _ ) => ADDMOD ()
+    rule #dasmOpCode(   9 :  _ ) => MULMOD ()
+    rule #dasmOpCode(  10 :  _ ) => EXPMOD ()
+    rule #dasmOpCode(  11 :  _ ) => SIGNEXTEND ()
+    rule #dasmOpCode(  12 :  _ ) => TWOS ()
+    rule #dasmOpCode(  13 :  _ ) => BSWAP ()
+    rule #dasmOpCode(  15 :  _ ) => NE ()
+    rule #dasmOpCode(  16 :  _ ) => LT ()
+    rule #dasmOpCode(  17 :  _ ) => GT ()
+    rule #dasmOpCode(  18 :  _ ) => LE ()
+    rule #dasmOpCode(  19 :  _ ) => GE ()
+    rule #dasmOpCode(  20 :  _ ) => EQ ()
+    rule #dasmOpCode(  21 :  _ ) => ISZERO ()
+    rule #dasmOpCode(  22 :  _ ) => AND ()
+    rule #dasmOpCode(  23 :  _ ) => OR ()
+    rule #dasmOpCode(  24 :  _ ) => XOR ()
+    rule #dasmOpCode(  25 :  _ ) => NOT ()
+    rule #dasmOpCode(  26 :  _ ) => BYTE ()
+    rule #dasmOpCode(  27 :  _ ) => SHIFT ()
+    rule #dasmOpCode(  28 :  _ ) => LOGARITHM2 ()
+    rule #dasmOpCode(  32 :  _ ) => SHA3 ()
+    rule #dasmOpCode(  48 :  _ ) => ADDRESS ()
+    rule #dasmOpCode(  49 :  _ ) => BALANCE ()
+    rule #dasmOpCode(  50 :  _ ) => ORIGIN ()
+    rule #dasmOpCode(  51 :  _ ) => CALLER ()
+    rule #dasmOpCode(  52 :  _ ) => CALLVALUE ()
+    rule #dasmOpCode(  56 :  _ ) => CODESIZE ()
+    rule #dasmOpCode(  58 :  _ ) => GASPRICE ()
+    rule #dasmOpCode(  59 :  _ ) => EXTCODESIZE ()
+    rule #dasmOpCode(  64 :  _ ) => BLOCKHASH ()
+    rule #dasmOpCode(  65 :  _ ) => BENEFICIARY ()
+    rule #dasmOpCode(  66 :  _ ) => TIMESTAMP ()
+    rule #dasmOpCode(  67 :  _ ) => NUMBER ()
+    rule #dasmOpCode(  68 :  _ ) => DIFFICULTY ()
+    rule #dasmOpCode(  69 :  _ ) => GASLIMIT ()
+    rule #dasmOpCode(  80 :  _ ) => MLOADN ()
+    rule #dasmOpCode(  81 :  _ ) => MLOAD ()
+    rule #dasmOpCode(  82 :  _ ) => MSTOREN ()
+    rule #dasmOpCode(  83 :  _ ) => MSTORE ()
+    rule #dasmOpCode(  84 :  _ ) => SLOAD ()
+    rule #dasmOpCode(  85 :  _ ) => SSTORE ()
+    rule #dasmOpCode(  86 :  _ ) => MSIZE ()
+    rule #dasmOpCode(  87 :  _ ) => GAS ()
+    rule #dasmOpCode(  96 :  _ ) => MOVE ()
+    rule #dasmOpCode(  97 : WS ) => #dasmLoad(97, #loadLen(WS), #loadOffset(WS), WS)
+    rule #dasmOpCode(  98 : WS ) => #dasmLoad(98, #loadLen(WS), #loadOffset(WS), WS)
+    rule #dasmOpCode( 100 : W1 : W2 : WS ) => BR(W1 *Int 256 +Int W2)
+    rule #dasmOpCode( 101 : W1 : W2 : WS ) => BRC(W1 *Int 256 +Int W2)
+    rule #dasmOpCode( 102 : W1 : W2 : WS ) => BRLABEL(W1 *Int 256 +Int W2)
+    rule #dasmOpCode( 160 :  _ ) => LOG0 ()
+    rule #dasmOpCode( 161 :  _ ) => LOG1 ()
+    rule #dasmOpCode( 162 :  _ ) => LOG2 ()
+    rule #dasmOpCode( 163 :  _ ) => LOG3 ()
+    rule #dasmOpCode( 164 :  _ ) => LOG4 ()
+    rule #dasmOpCode( 240 : W1 : W2 : W3 : W4 : WS ) => CREATE(W1 *Int 256 +Int W2, W3 *Int 256 +Int W4)
+    rule #dasmOpCode( 241 : W1 : W2 : WS ) => COPYCREATE(W1 *Int 256 +Int W2)
+    rule #dasmOpCode( 242 : W1 : W2 : W3 : W4 : W5 : W6 : WS ) => CALL(W1 *Int 256 +Int W2, W3 *Int 256 +Int W4, W5 *Int 256 +Int W6)
+    rule #dasmOpCode( 243 : W1 : W2 : W3 : W4 : WS ) => CALLDYN(W1 *Int 256 +Int W2, W3 *Int 256 +Int W4)
+    rule #dasmOpCode( 244 : W1 : W2 : W3 : W4 : W5 : W6 : WS ) => STATICCALL(W1 *Int 256 +Int W2, W3 *Int 256 +Int W4, W5 *Int 256 +Int W6)
+    rule #dasmOpCode( 245 : W1 : W2 : W3 : W4 : WS ) => STATICCALLDYN(W1 *Int 256 +Int W2, W3 *Int 256 +Int W4)
+    rule #dasmOpCode( 246 : W1 : W2 : WS ) => RETURN(W1 *Int 256 +Int W2)
+    rule #dasmOpCode( 247 :  _ ) => REVERT()
+    rule #dasmOpCode( 248 : W1 : W2 : W3 : W4 : W5 : W6 : WS ) => LOCALCALL(W1 *Int 256 +Int W2, W3 *Int 256 +Int W4, W5 *Int 256 +Int W6)
+    rule #dasmOpCode( 249 : W1 : W2 : W3 : W4 : WS ) => LOCALCALLDYN(W1 *Int 256 +Int W2, W3 *Int 256 +Int W4)
+    rule #dasmOpCode( 250 : W1 : W2 : WS ) => CALLADDRESS(W1 *Int 256 +Int W2)
+    rule #dasmOpCode( 254 :  _ ) => INVALID ()
+    rule #dasmOpCode( 255 :  _ ) => SELFDESTRUCT ()
+    rule #dasmOpCode( _ ) => encodingError() [owise]
 
+    syntax OpCode ::= #dasmLoad ( Int , Int , Int , WordStack ) [function]
+ // ----------------------------------------------------------------------
+    rule #dasmLoad(97, LEN, POS, WS) => LOADPOS(LEN +Int POS, #asUnsigned(WS [ POS .. LEN ]))
+    rule #dasmLoad(98, LEN, POS, WS) => LOADNEG(LEN +Int POS, #asUnsigned(WS [ POS .. LEN ]))
 
 endmodule
 ```

--- a/iele-node.md
+++ b/iele-node.md
@@ -60,7 +60,7 @@ module IELE-NODE
           => #fun(CODE => #fun(CONTRACT =>
              #checkContract CONTRACT
           ~> #create ACCTFROM #newAddr(ACCTFROM, NONCE -Int 1) GAVAIL VALUE CONTRACT #toInts(ARGS)
-          ~> #codeDeposit #newAddr(ACCTFROM, NONCE -Int 1) #sizeWordStack(CODE) CONTRACT %0 %1 true)(#dasmContract(CODE, Main)))(#parseByteStackRaw(CODESTR))
+          ~> #codeDeposit #newAddr(ACCTFROM, NONCE -Int 1) #sizeWordStack(CODE) CONTRACT %0 %1 true)(#if #isValidContract(CODE) #then #dasmContract(CODE, Main) #else #illFormed #fi))(#parseByteStackRaw(CODESTR))
          ...
          </k>
          <schedule> SCHED </schedule>

--- a/iele.md
+++ b/iele.md
@@ -1323,9 +1323,9 @@ For each `call*` operation, we make a corresponding call to `#call` and a state-
                         | "#checkCreate" Int Int
                         | "#checkContract" Contract
                         | "#finishTypeChecking"
-                        | "#illFormed"
- // -----------------------------------------------
-    rule <k> #checkCreate ACCT VALUE ~> #create _ _ GAVAIL _ _ _ _ => #refund GAVAIL ~> #pushCallStack ~> #pushWorldState ~> #pushSubstate ~> #exception (#if VALUE >Int BAL #then OUT_OF_FUNDS #else CALL_STACK_OVERFLOW #fi) ... </k>
+    syntax Contract ::= "#illFormed"
+ // --------------------------------
+    rule <k> #checkCreate ACCT VALUE ~> #create _ _ GAVAIL _ _ _ => #refund GAVAIL ~> #pushCallStack ~> #pushWorldState ~> #pushSubstate ~> #exception (#if VALUE >Int BAL #then OUT_OF_FUNDS #else CALL_STACK_OVERFLOW #fi) ... </k>
          <callDepth> CD </callDepth>
          <output> _ => .Ints </output>
          <account>
@@ -1362,7 +1362,7 @@ For each `call*` operation, we make a corresponding call to `#call` and a state-
     rule <k> #illFormed ~> (K:KItem => .) ... </k>
       requires K =/=K #finishTypeChecking
 
-    rule <k> #illFormed ~> #finishTypeChecking ~> #create _ _ GAVAIL _ _ _ _ => #refund GAVAIL ~> #pushCallStack ~> #pushWorldState ~> #pushSubstate ~> #exception CONTRACT_INVALID ... </k>
+    rule <k> #illFormed ~> #finishTypeChecking ~> #create _ _ GAVAIL _ _ _ => #refund GAVAIL ~> #pushCallStack ~> #pushWorldState ~> #pushSubstate ~> #exception CONTRACT_INVALID ... </k>
          <typeChecking> true => false </typeChecking>
 
     rule #create ACCTFROM ACCTTO GAVAIL VALUE CODE ARGS

--- a/iele.md
+++ b/iele.md
@@ -710,8 +710,9 @@ Note that the syntax used in the following `#emptyCode` macro is desugared IELE 
 
 ```k
     syntax IeleName ::= "Main" [token]
+                      | "iele.Wallet" [token]
  // ----------------------------------
-    rule #emptyCode => contract Main !0 "" { define public @deposit ( 0 ) { ret .NonEmptyOperands .Instructions .LabeledBlocks } } .Contract [macro]
+    rule #emptyCode => contract iele.Wallet !0 "" { define public @deposit ( 0 ) { ret .NonEmptyOperands .Instructions .LabeledBlocks } } .Contract [macro]
 ```
 
 ### Register Manipulations

--- a/tests/evm-to-iele/conversion.ml
+++ b/tests/evm-to-iele/conversion.ml
@@ -814,6 +814,7 @@ let rec postprocess_iele iele label memcells = match iele with
 | VoidOp(`MSTORE, [r1;r2]) :: tl -> VoidOp(`MSTORE, [r2;r1]) :: postprocess_iele tl label memcells
 | VoidOp(`MSTOREN, [r1;r2;r3;r4]) :: tl -> VoidOp(`MSTOREN, [r3;r1;r2;r4]) :: postprocess_iele tl label memcells
 | Op(`SIGNEXTEND, reg, [r1;r2]) :: tl -> LiOp(`LOADPOS, -1, _32) :: Op(`TWOS, r2, [-1;r2]) :: LiOp(`LOADPOS, -1, Z.one) :: Op(`ADD, r1, [-1;r1]) :: Op(`SIGNEXTEND, reg, [r1;r2]) :: postprocess_iele tl label memcells
+| VoidOp((`EXTCODECOPY | `CODECOPY), _) :: tl -> VoidOp(`INVALID, []) :: postprocess_iele tl label memcells
 | hd :: tl -> hd :: postprocess_iele tl label memcells
 | [] -> []
 

--- a/tests/evm-to-iele/iele.ml
+++ b/tests/evm-to-iele/iele.ml
@@ -179,9 +179,9 @@ let asm_iele_op op buf nregs = match op with
   asm_iele_regs (regs1 @ regs2) buf nregs
 | LiOp(opcode,r,payload) ->
   Buffer.add_string buf (asm_iele_opcode opcode);
-  asm_iele_regs [r] buf nregs;
   let payload_be = IeleUtil.be_int payload in
-  Buffer.add_string buf (IeleUtil.rlp_encode_string payload_be)
+  Buffer.add_string buf (IeleUtil.rlp_encode_string payload_be);
+  asm_iele_regs [r] buf nregs
 
 let rec asm_iele_aux ops buf nregs = match ops with
 | [] -> ()

--- a/tests/evm-to-iele/iele.ml
+++ b/tests/evm-to-iele/iele.ml
@@ -152,8 +152,8 @@ let asm_iele_opcode op = match op with
 | `COPYCREATE -> "\xf1\x00\x00\x00\x00"
 | `CALL(call,nargs,nreturn) -> "\xf2" ^ (IeleUtil.be_int_width (Z.of_int call) 16) ^ (IeleUtil.be_int_width (Z.of_int nargs) 16) ^ (IeleUtil.be_int_width (Z.of_int nreturn) 16)
 | `CALLCODE(call,nargs,nreturn) -> "\xf3" ^ (IeleUtil.be_int_width (Z.of_int call) 16) ^ (IeleUtil.be_int_width (Z.of_int nargs) 16) ^ (IeleUtil.be_int_width (Z.of_int nreturn) 16)
-| `DELEGATECALL(call,nargs,nreturn) -> "\xf4" ^ (IeleUtil.be_int_width (Z.of_int call) 16) ^ (IeleUtil.be_int_width (Z.of_int nargs) 16) ^ (IeleUtil.be_int_width (Z.of_int nreturn) 16)
-| `STATICCALL(call,nargs,nreturn) -> "\xf5" ^ (IeleUtil.be_int_width (Z.of_int call) 16) ^ (IeleUtil.be_int_width (Z.of_int nargs) 16) ^ (IeleUtil.be_int_width (Z.of_int nreturn) 16)
+| `DELEGATECALL(call,nargs,nreturn) -> "\xf5" ^ (IeleUtil.be_int_width (Z.of_int call) 16) ^ (IeleUtil.be_int_width (Z.of_int nargs) 16) ^ (IeleUtil.be_int_width (Z.of_int nreturn) 16)
+| `STATICCALL(call,nargs,nreturn) -> "\xf4" ^ (IeleUtil.be_int_width (Z.of_int call) 16) ^ (IeleUtil.be_int_width (Z.of_int nargs) 16) ^ (IeleUtil.be_int_width (Z.of_int nreturn) 16)
 | `RETURN(nreturn) -> "\xf6" ^ (IeleUtil.be_int_width (Z.of_int nreturn) 16)
 | `REVERT(nreturn) -> "\xf7"
 | `LOCALCALL (call,nargs,nreturn) -> "\xf8" ^ (IeleUtil.be_int_width (Z.of_int call) 16) ^ (IeleUtil.be_int_width (Z.of_int nargs) 16) ^ (IeleUtil.be_int_width (Z.of_int nreturn) 16)

--- a/tests/evm-to-iele/iele.ml
+++ b/tests/evm-to-iele/iele.ml
@@ -155,7 +155,7 @@ let asm_iele_opcode op = match op with
 | `DELEGATECALL(call,nargs,nreturn) -> "\xf4" ^ (IeleUtil.be_int_width (Z.of_int call) 16) ^ (IeleUtil.be_int_width (Z.of_int nargs) 16) ^ (IeleUtil.be_int_width (Z.of_int nreturn) 16)
 | `STATICCALL(call,nargs,nreturn) -> "\xf5" ^ (IeleUtil.be_int_width (Z.of_int call) 16) ^ (IeleUtil.be_int_width (Z.of_int nargs) 16) ^ (IeleUtil.be_int_width (Z.of_int nreturn) 16)
 | `RETURN(nreturn) -> "\xf6" ^ (IeleUtil.be_int_width (Z.of_int nreturn) 16)
-| `REVERT(nreturn) -> "\xf7" ^ (IeleUtil.be_int_width (Z.of_int nreturn) 16)
+| `REVERT(nreturn) -> "\xf7"
 | `LOCALCALL (call,nargs,nreturn) -> "\xf8" ^ (IeleUtil.be_int_width (Z.of_int call) 16) ^ (IeleUtil.be_int_width (Z.of_int nargs) 16) ^ (IeleUtil.be_int_width (Z.of_int nreturn) 16)
 | `LOCALRETURN(nreturn) -> "\xf6" ^ (IeleUtil.be_int_width (Z.of_int nreturn) 16)
 | `INVALID -> "\xfe"

--- a/tests/iele/auction/create.iele.json
+++ b/tests/iele/auction/create.iele.json
@@ -14,7 +14,7 @@
                     {
                         "out": ["0x6295ee1b4f6dd65047762f924ecd367c17eabf8f"],
                         "status": "",
-                        "gas": "0x0daddc",
+                        "gas": "0x0db18c",
                         "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
                         "refund": ""
                     }

--- a/tests/iele/ill-formed/illFormed2.iele.json
+++ b/tests/iele/ill-formed/illFormed2.iele.json
@@ -56,21 +56,42 @@
                     {
                         "out": [],
                         "status": "0x09",
-                        "gas": "0x0f1954",
+                        "gas": "0x0f18d4",
                         "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
                         "refund": ""
                     },
                     {
                         "out": [],
                         "status": "0x09",
-                        "gas": "0x0f2f08",
+                        "gas": "0x0f2f54",
                         "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
                         "refund": ""
                     },
                     {
                         "out": [],
                         "status": "0x09",
-                        "gas": "0x0f2e70",
+                        "gas": "0x0f2ebc",
+                        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
+                        "refund": ""
+                    },
+                    {
+                        "out": [],
+                        "status": "0x09",
+                        "gas": "0x0f1690",
+                        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
+                        "refund": ""
+                    },
+                    {
+                        "out": [],
+                        "status": "0x09",
+                        "gas": "0x0f1690",
+                        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
+                        "refund": ""
+                    },
+                    {
+                        "out": [],
+                        "status": "0x09",
+                        "gas": "0x0f16d0",
                         "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
                         "refund": ""
                     },
@@ -84,26 +105,12 @@
                     {
                         "out": [],
                         "status": "0x09",
-                        "gas": "0x0f1710",
+                        "gas": "0x0f2e24",
                         "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
                         "refund": ""
                     },
                     {
-                        "out": [],
-                        "status": "0x09",
-                        "gas": "0x0f1790",
-                        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
-                        "refund": ""
-                    },
-                    {
-                        "out": [],
-                        "status": "0x09",
-                        "gas": "0x0f2dd8",
-                        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
-                        "refund": ""
-                    },
-                    {
-                        "out": ["0x9f084f0197ed97a5a2b0ccf1cf5049810ac18f89"],
+                        "out": ["0xbed5dcef9d709c1ff512238f9cab55d5105ecc39"],
                         "status": "",
                         "gas": "0x0f1b45",
                         "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
@@ -184,7 +191,7 @@
                         "value": "0x00", 
                         "to": "",
                         "arguments": [], 
-                        "contractCode": "0x00000060635e6a00006700000000680000000067000000008315cfca19d39a542be53bad24f9e0a93c5e2a24dfb3c99acec3d50a63e4ec679ad54e6613cf9fa0b779b8863e695639e0d8c1a5769b9077d016341d83b631cb389f520c317ed360c4d64d72",
+                        "contractCode": "0x00000060635e6700000000680000000067000000000123458315cfca19d39a542be53bad24f9e0a93c5e2a24dfb3c99acec3d50a63e4ec679ad54e6613cf9fa0b779b8863e695639e0d8c1a5769b9077d016341d83b631cb389f520c317ed360c4d64d72",
                         "gasPrice": "0x01",
                         "from": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
                     },
@@ -195,7 +202,7 @@
                         "value": "0x00", 
                         "to": "",
                         "arguments": [], 
-                        "contractCode": "0x00000005635e6a0000",
+                        "contractCode": "0x00000002635e",
                         "gasPrice": "0x01",
                         "from": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
                     },
@@ -206,7 +213,7 @@
                         "value": "0x00", 
                         "to": "",
                         "arguments": [], 
-                        "contractCode": "0x0000000b635e6a0000670000000066",
+                        "contractCode": "0x00000008635e670000000066",
                         "gasPrice": "0x01",
                         "from": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
                     },
@@ -217,7 +224,7 @@
                         "value": "0x00", 
                         "to": "",
                         "arguments": [], 
-                        "contractCode": "0x00000060635e6a0000670000000061bfca19d39a542be53bad24f9e0a93c5e2a24dfb3c99acec3d50a63e4ec679ad54e6613cf9fa0b779b8863e695639e0d8c1a5769b9077d016341d83b631cb389f520c317ed360c4d64d72e39826707dfcd95304312250",
+                        "contractCode": "0x00000060635e670000000061bf012345ca19d39a542be53bad24f9e0a93c5e2a24dfb3c99acec3d50a63e4ec679ad54e6613cf9fa0b779b8863e695639e0d8c1a5769b9077d016341d83b631cb389f520c317ed360c4d64d72e39826707dfcd95304312250",
                         "gasPrice": "0x01",
                         "from": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
                     },
@@ -228,7 +235,7 @@
                         "value": "0x00", 
                         "to": "",
                         "arguments": [], 
-                        "contractCode": "0x0000006063ff6a0000670000000001bfca19d39a542be53bad24f9e0a93c5e2a24dfb3c99acec3d50a63e4ec679ad54e6613cf9fa0b779b8863e695639e0d8c1a5769b9077d016341d83b631cb389f520c317ed360c4d64d72e39826707dfcd95304312250",
+                        "contractCode": "0x0000006063ff670000000001012345bfca19d39a542be53bad24f9e0a93c5e2a24dfb3c99acec3d50a63e4ec679ad54e6613cf9fa0b779b8863e695639e0d8c1a5769b9077d016341d83b631cb389f520c317ed360c4d64d72e39826707dfcd95304312250",
                         "gasPrice": "0x01",
                         "from": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
                     },
@@ -239,7 +246,7 @@
                         "value": "0x00", 
                         "to": "",
                         "arguments": [], 
-                        "contractCode": "0x0000006063046a00006700000000f2ffffffff00002be53bad24f9e0a93c5e2a24dfb3c99acec3d50a63e4ec679ad54e6613cf9fa0b779b8863e695639e0d8c1a5769b9077d016341d83b631cb389f520c317ed360c4d64d72e39826707dfcd95304312250",
+                        "contractCode": "0x0000006063ff670000000000012345bfca19d39a542be53bad24f9e0a93c5e2a24dfb3c99acec3d50a63e4ec679ad54e6613cf9fa0b779b8863e695639e0d8c1a5769b9077d016341d83b631cb389f520c317ed360c4d64d72e39826707dfcd95304312250",
                         "gasPrice": "0x01",
                         "from": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
                     },
@@ -250,7 +257,18 @@
                         "value": "0x00", 
                         "to": "",
                         "arguments": [], 
-                        "contractCode": "0x0000001163046a00006700000000f8ffff00000000",
+                        "contractCode": "0x0000006063046700000000f2ffffffff00000123452be53bad24f9e0a93c5e2a24dfb3c99acec3d50a63e4ec679ad54e6613cf9fa0b779b8863e695639e0d8c1a5769b9077d016341d83b631cb389f520c317ed360c4d64d72e39826707dfcd95304312250",
+                        "gasPrice": "0x01",
+                        "from": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
+                    },
+                    {
+                        "nonce": "0x00", 
+                        "function": "", 
+                        "gasLimit": "0x100000", 
+                        "value": "0x00", 
+                        "to": "",
+                        "arguments": [], 
+                        "contractCode": "0x0000000e63046700000000f8ffff00000000",
                         "gasPrice": "0x01",
                         "from": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
                     },
@@ -279,12 +297,12 @@
         "blockhashes": ["0x24a30e4305ac41674b26493c800c05f507e98d3b8bceb0a314f9b9bc43622736", "0x00"],
         "postState": {
             "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
-                "nonce": "0x0e",
-                "balance": "0xe8d3c51000",
+                "nonce": "0x0f",
+                "balance": "0xe8d3b51000",
                 "storage": {},
                 "code": ""
             },
-            "0x9f084f0197ed97a5a2b0ccf1cf5049810ac18f89": {
+            "0xbed5dcef9d709c1ff512238f9cab55d5105ecc39": {
                 "nonce": "0x01",
                 "balance": "0x00",
                 "storage": {},

--- a/tests/iele/ill-formed/illFormed2.iele.json
+++ b/tests/iele/ill-formed/illFormed2.iele.json
@@ -1,0 +1,295 @@
+{
+    "BLOCKHASH": {
+        "pre": {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+                "nonce": "0x00",
+                "balance": "0xe8d4a51000",
+                "storage": {},
+                "code": ""
+            }
+        },
+        "blocks": [
+            {
+                "results": [
+                    {
+                        "out": [],
+                        "status": "0x09",
+                        "gas": "0x0f1554",
+                        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
+                        "refund": ""
+                    },
+                    {
+                        "out": [],
+                        "status": "0x09",
+                        "gas": "0x0f1554",
+                        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
+                        "refund": ""
+                    },
+                    {
+                        "out": [],
+                        "status": "0x09",
+                        "gas": "0x0f1614",
+                        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
+                        "refund": ""
+                    },
+                    {
+                        "out": [],
+                        "status": "0x09",
+                        "gas": "0x0f1614",
+                        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
+                        "refund": ""
+                    },
+                    {
+                        "out": [],
+                        "status": "0x09",
+                        "gas": "0x0f1614",
+                        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
+                        "refund": ""
+                    },
+                    {
+                        "out": [],
+                        "status": "0x09",
+                        "gas": "0x0f1694",
+                        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
+                        "refund": ""
+                    },
+                    {
+                        "out": [],
+                        "status": "0x09",
+                        "gas": "0x0f1954",
+                        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
+                        "refund": ""
+                    },
+                    {
+                        "out": [],
+                        "status": "0x09",
+                        "gas": "0x0f2f08",
+                        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
+                        "refund": ""
+                    },
+                    {
+                        "out": [],
+                        "status": "0x09",
+                        "gas": "0x0f2e70",
+                        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
+                        "refund": ""
+                    },
+                    {
+                        "out": [],
+                        "status": "0x09",
+                        "gas": "0x0f1710",
+                        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
+                        "refund": ""
+                    },
+                    {
+                        "out": [],
+                        "status": "0x09",
+                        "gas": "0x0f1710",
+                        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
+                        "refund": ""
+                    },
+                    {
+                        "out": [],
+                        "status": "0x09",
+                        "gas": "0x0f1790",
+                        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
+                        "refund": ""
+                    },
+                    {
+                        "out": [],
+                        "status": "0x09",
+                        "gas": "0x0f2dd8",
+                        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
+                        "refund": ""
+                    },
+                    {
+                        "out": ["0x9f084f0197ed97a5a2b0ccf1cf5049810ac18f89"],
+                        "status": "",
+                        "gas": "0x0f1b45",
+                        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
+                        "refund": ""
+                    }
+                ],
+                "transactions": [
+                    {
+                        "nonce": "0x00", 
+                        "function": "", 
+                        "gasLimit": "0x100000", 
+                        "value": "0x00", 
+                        "to": "",
+                        "arguments": [], 
+                        "contractCode": "0xa8bf7d70815e10476c9600f58315cfca19d39a542be53bad24f9e0a93c5e2a24dfb3c99acec3d50a63e4ec679ad54e6613cf9fa0b779b8863e695639e0d8c1a5769b9077d016341d83b631cb389f520c317ed360c4d64d72e39826707dfcd95304312250",
+                        "gasPrice": "0x01",
+                        "from": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
+                    },
+                    {
+                        "nonce": "0x00", 
+                        "function": "", 
+                        "gasLimit": "0x100000", 
+                        "value": "0x00", 
+                        "to": "",
+                        "arguments": [], 
+                        "contractCode": "0xa8bf7d70635e10476c9600f58315cfca19d39a542be53bad24f9e0a93c5e2a24dfb3c99acec3d50a63e4ec679ad54e6613cf9fa0b779b8863e695639e0d8c1a5769b9077d016341d83b631cb389f520c317ed360c4d64d72e39826707dfcd95304312250",
+                        "gasPrice": "0x01",
+                        "from": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
+                    },
+                    {
+                        "nonce": "0x00", 
+                        "function": "", 
+                        "gasLimit": "0x100000", 
+                        "value": "0x00", 
+                        "to": "",
+                        "arguments": [], 
+                        "contractCode": "0x00000060635e10476c9600f58315cfca19d39a542be53bad24f9e0a93c5e2a24dfb3c99acec3d50a63e4ec679ad54e6613cf9fa0b779b8863e695639e0d8c1a5769b9077d016341d83b631cb389f520c317ed360c4d64d72e39826707dfcd95304312250",
+                        "gasPrice": "0x01",
+                        "from": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
+                    },
+                    {
+                        "nonce": "0x00", 
+                        "function": "", 
+                        "gasLimit": "0x100000", 
+                        "value": "0x00", 
+                        "to": "",
+                        "arguments": [], 
+                        "contractCode": "0x00000060635e69476c9600f58315cfca19d39a542be53bad24f9e0a93c5e2a24dfb3c99acec3d50a63e4ec679ad54e6613cf9fa0b779b8863e695639e0d8c1a5769b9077d016341d83b631cb389f520c317ed360c4d64d72e39826707dfcd95304312250",
+                        "gasPrice": "0x01",
+                        "from": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
+                    },
+                    {
+                        "nonce": "0x00", 
+                        "function": "", 
+                        "gasLimit": "0x100000", 
+                        "value": "0x00", 
+                        "to": "",
+                        "arguments": [], 
+                        "contractCode": "0x00000060635e6a476c9600f58315cfca19d39a542be53bad24f9e0a93c5e2a24dfb3c99acec3d50a63e4ec679ad54e6613cf9fa0b779b8863e695639e0d8c1a5769b9077d016341d83b631cb389f520c317ed360c4d64d72e39826707dfcd95304312250",
+                        "gasPrice": "0x01",
+                        "from": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
+                    },
+                    {
+                        "nonce": "0x00", 
+                        "function": "", 
+                        "gasLimit": "0x100000", 
+                        "value": "0x00", 
+                        "to": "",
+                        "arguments": [], 
+                        "contractCode": "0x00000060635e6a00009600f58315cfca19d39a542be53bad24f9e0a93c5e2a24dfb3c99acec3d50a63e4ec679ad54e6613cf9fa0b779b8863e695639e0d8c1a5769b9077d016341d83b631cb389f520c317ed360c4d64d72e39826707dfcd95304312250",
+                        "gasPrice": "0x01",
+                        "from": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
+                    },
+                    {
+                        "nonce": "0x00", 
+                        "function": "", 
+                        "gasLimit": "0x100000", 
+                        "value": "0x00", 
+                        "to": "",
+                        "arguments": [], 
+                        "contractCode": "0x00000060635e6a00006700000000680000000067000000008315cfca19d39a542be53bad24f9e0a93c5e2a24dfb3c99acec3d50a63e4ec679ad54e6613cf9fa0b779b8863e695639e0d8c1a5769b9077d016341d83b631cb389f520c317ed360c4d64d72",
+                        "gasPrice": "0x01",
+                        "from": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
+                    },
+                    {
+                        "nonce": "0x00", 
+                        "function": "", 
+                        "gasLimit": "0x100000", 
+                        "value": "0x00", 
+                        "to": "",
+                        "arguments": [], 
+                        "contractCode": "0x00000005635e6a0000",
+                        "gasPrice": "0x01",
+                        "from": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
+                    },
+                    {
+                        "nonce": "0x00", 
+                        "function": "", 
+                        "gasLimit": "0x100000", 
+                        "value": "0x00", 
+                        "to": "",
+                        "arguments": [], 
+                        "contractCode": "0x0000000b635e6a0000670000000066",
+                        "gasPrice": "0x01",
+                        "from": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
+                    },
+                    {
+                        "nonce": "0x00", 
+                        "function": "", 
+                        "gasLimit": "0x100000", 
+                        "value": "0x00", 
+                        "to": "",
+                        "arguments": [], 
+                        "contractCode": "0x00000060635e6a0000670000000061bfca19d39a542be53bad24f9e0a93c5e2a24dfb3c99acec3d50a63e4ec679ad54e6613cf9fa0b779b8863e695639e0d8c1a5769b9077d016341d83b631cb389f520c317ed360c4d64d72e39826707dfcd95304312250",
+                        "gasPrice": "0x01",
+                        "from": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
+                    },
+                    {
+                        "nonce": "0x00", 
+                        "function": "", 
+                        "gasLimit": "0x100000", 
+                        "value": "0x00", 
+                        "to": "",
+                        "arguments": [], 
+                        "contractCode": "0x0000006063ff6a0000670000000001bfca19d39a542be53bad24f9e0a93c5e2a24dfb3c99acec3d50a63e4ec679ad54e6613cf9fa0b779b8863e695639e0d8c1a5769b9077d016341d83b631cb389f520c317ed360c4d64d72e39826707dfcd95304312250",
+                        "gasPrice": "0x01",
+                        "from": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
+                    },
+                    {
+                        "nonce": "0x00", 
+                        "function": "", 
+                        "gasLimit": "0x100000", 
+                        "value": "0x00", 
+                        "to": "",
+                        "arguments": [], 
+                        "contractCode": "0x0000006063046a00006700000000f2ffffffff00002be53bad24f9e0a93c5e2a24dfb3c99acec3d50a63e4ec679ad54e6613cf9fa0b779b8863e695639e0d8c1a5769b9077d016341d83b631cb389f520c317ed360c4d64d72e39826707dfcd95304312250",
+                        "gasPrice": "0x01",
+                        "from": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
+                    },
+                    {
+                        "nonce": "0x00", 
+                        "function": "", 
+                        "gasLimit": "0x100000", 
+                        "value": "0x00", 
+                        "to": "",
+                        "arguments": [], 
+                        "contractCode": "0x0000001163046a00006700000000f8ffff00000000",
+                        "gasPrice": "0x01",
+                        "from": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
+                    },
+                    {
+                        "nonce": "0x00", 
+                        "function": "", 
+                        "gasLimit": "0x100000", 
+                        "value": "0x00", 
+                        "to": "",
+                        "arguments": [], 
+                        "contractCode": "0x0000001363046700000000f8ffff0000000067ffff0000",
+                        "gasPrice": "0x01",
+                        "from": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
+                    }
+                ], 
+                "blockHeader": {
+                    "gasLimit": "0x174876e800", 
+                    "number": "0x01", 
+                    "difficulty": "0x020000", 
+                    "timestamp": "0x03e8", 
+                    "coinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba"
+                }
+            }
+        ], 
+        "network": "Albe", 
+        "blockhashes": ["0x24a30e4305ac41674b26493c800c05f507e98d3b8bceb0a314f9b9bc43622736", "0x00"],
+        "postState": {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+                "nonce": "0x0e",
+                "balance": "0xe8d3c51000",
+                "storage": {},
+                "code": ""
+            },
+            "0x9f084f0197ed97a5a2b0ccf1cf5049810ac18f89": {
+                "nonce": "0x01",
+                "balance": "0x00",
+                "storage": {},
+                "code": "0x0000001363046700000000f8ffff0000000067ffff0000"
+            }
+        }
+    }
+}

--- a/well-formedness.md
+++ b/well-formedness.md
@@ -316,8 +316,8 @@ Reserved Names
 All identifiers beginning with "iele." are reserved by the language and cannot be written to.
 
 ```k
-    syntax K ::= checkName(IeleName) [function]
- // -------------------------------------------
+    syntax K ::= checkName(IeleName)
+ // --------------------------------
     rule checkName(NAME) => .
       requires lengthString(IeleName2String(NAME)) <Int 5 orBool substrString(IeleName2String(NAME), 0, 5) =/=String "iele."
 


### PR DESCRIPTION
Code that checks to make sure we can successfully disassemble the contract prior to actually trying to disassemble it.

This prevents crashes in cases where we previously had not given semantics, but also closes attack vectors where previously large immediate constants could have led to an improperly large amount of time spent trying to disassemble a maliciously constructed contract.

Fixes #121

Ready for review.