### PR TITLE
Run in haskell backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ haskell-deps:
 .build/haskell/definition.kore: $(defn_files)
 	@echo "== kompile: $@"
 	${KOMPILE} --debug --main-module IELE-TESTING --backend haskell \
-					--syntax-module IELE-SYNTAX .build/standalone/iele-testing.k --directory .build/haskell -I .build/haskell
+					--syntax-module IELE-TESTING .build/standalone/iele-testing.k --directory .build/haskell -I .build/haskell
 
 .build/%/iele-testing-kompiled/constants.$(EXT): $(defn_files)
 	@echo "== kompile: $@"

--- a/vmtest-haskell
+++ b/vmtest-haskell
@@ -4,10 +4,9 @@ KRUN_BINARY=".build/rv-k/k-distribution/target/release/k/bin/krun"
 KOMPILED_DEF=".build/haskell/"
 HASKELL_BACKEND_CMD=".build/kore/bin/kore-exec"
 
-cSCHEDULE='`DEFAULT_IELE-GAS`(.KList)'
-cMODE='`VMTESTS_IELE-CONSTANTS`(.KList)'
+cSCHEDULE=DEFAULT
+cMODE=VMTESTS
 
 PGM=$1
 
-$KRUN_BINARY --directory "$KOMPILED_DEF" "$PGM" --haskell-backend-command "$HASKELL_BACKEND_CMD"
-# $KRUN_BINARY --directory "$KOMPILED_DEF" -cSCHEDULE="$cSCHEDULE" -pSCHEDULE='printf %s' -cMODE="$cMODE" -pMODE='printf %s' "$PGM" --haskell-backend-command "$HASKELL_BACKEND_CMD"
+$KRUN_BINARY --directory "$KOMPILED_DEF" -cSCHEDULE="$cSCHEDULE" -pSCHEDULE='printf %s' -cMODE="$cMODE" -pMODE='printf %s' "$PGM" --haskell-backend-command "$HASKELL_BACKEND_CMD"

--- a/vmtest-haskell
+++ b/vmtest-haskell
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+KRUN_BINARY=".build/rv-k/k-distribution/target/release/k/bin/krun"
+KOMPILED_DEF=".build/haskell/"
+HASKELL_BACKEND_CMD=".build/kore/bin/kore-exec"
+
+cSCHEDULE='`DEFAULT_IELE-GAS`(.KList)'
+cMODE='`VMTESTS_IELE-CONSTANTS`(.KList)'
+
+PGM=$1
+
+$KRUN_BINARY --directory "$KOMPILED_DEF" "$PGM" --haskell-backend-command "$HASKELL_BACKEND_CMD"
+# $KRUN_BINARY --directory "$KOMPILED_DEF" -cSCHEDULE="$cSCHEDULE" -pSCHEDULE='printf %s' -cMODE="$cMODE" -pMODE='printf %s' "$PGM" --haskell-backend-command "$HASKELL_BACKEND_CMD"

--- a/vmtest-haskell
+++ b/vmtest-haskell
@@ -9,4 +9,4 @@ cMODE=VMTESTS
 
 PGM=$1
 
-$KRUN_BINARY --directory "$KOMPILED_DEF" -cSCHEDULE="$cSCHEDULE" -pSCHEDULE='printf %s' -cMODE="$cMODE" -pMODE='printf %s' "$PGM" --haskell-backend-command "$HASKELL_BACKEND_CMD"
+$KRUN_BINARY --directory "$KOMPILED_DEF" -cSCHEDULE="$cSCHEDULE" -cMODE="$cMODE" "$PGM" --haskell-backend-command "$HASKELL_BACKEND_CMD"


### PR DESCRIPTION
Adding a simple script, similar to `vmtest`, that runs a IELE program on the Haskell backend. 
It's not fully functional/finished. 