### PR TITLE
Remove set_gc_interval

### DIFF
--- a/vm/c/main.cpp
+++ b/vm/c/main.cpp
@@ -48,7 +48,6 @@ int init(int port, in_addr host) {
     perror("listen");
     exit(1);
   }
-  set_gc_interval(10000);
   return sock;
 }
 


### PR DESCRIPTION
`set_gc_interval` was removed from the LLVM backend.