### PR TITLE
Add Release workflow to create release.nix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: "Release"
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  nix-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2.3.4
+        with:
+          submodules: recursive
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v12
+
+      - name: Upload release.nix
+        uses: ttuegel/upload-release.nix@v1.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is required for runtimeverification/solidity#175 because the Solidity compiler depends on `iele-assemble`. This is the same process used for the K Framework release.