### PR TITLE
Fix in the #loadLen helper

### DIFF
--- a/data.md
+++ b/data.md
@@ -460,7 +460,7 @@ Decoding
  // --------------------------------------------
     rule #loadLen ( WS ) => 1                                  requires WS[0]  <Int 128 orBool  WS[0] >=Int 192
     rule #loadLen ( WS ) => WS[0] -Int 128                     requires WS[0] >=Int 128 andBool WS[0]  <Int 184
-    rule #loadLen ( WS ) => #asUnsigned(0, WS[0] -Int 183, WS) requires WS[0] >=Int 184 andBool WS[0]  <Int 192
+    rule #loadLen ( WS ) => #asUnsigned(1, WS[0] -Int 183, WS) requires WS[0] >=Int 184 andBool WS[0]  <Int 192
 
     syntax Int ::= #loadOffset ( Bytes ) [function]
  // -----------------------------------------------


### PR DESCRIPTION
This fixes a regression introduced in the replacement of `WordStack` with `Bytes`.

The regression was introduced by the change found [here](https://github.com/runtimeverification/iele-semantics/commit/816c1c125fe1bb0f5621c98cc76787b07e747963#diff-8646165c2d354850965539efadf4790e50a9589382a98f1b5b2e07d54e62a15dR463).

The bug was introduced because the newer version failed to skip the first byte of the RLP encoded bytestring before decoding the next byte(s) into the length.

Fixes https://github.com/runtimeverification/iog-pm/issues/85