### PR TITLE
fix for bswap instruction

### DIFF
--- a/iele.md
+++ b/iele.md
@@ -840,8 +840,8 @@ Expression calculations are simple and don't require anything but the arguments 
     rule <k> #exec REG = sext  WIDTH , W => #load REG signextend(chop(WIDTH), W) ... </k> requires W >=Int 0
     rule <k> #exec REG = sext  WIDTH , W => #exception USER_ERROR                ... </k> requires W <Int 0
     rule <k> #exec REG = twos  WIDTH , W => #load REG twos(chop(WIDTH), W)       ... </k>
-    rule <k> #exec REG = bswap WIDTH , W => #load REG bswap(chop(WIDTH), W)      ... </k> requires W >=Int 0
-    rule <k> #exec REG = bswap WIDTH , W => #exception USER_ERROR                ... </k> requires W <Int 0
+    rule <k> #exec REG = bswap WIDTH , W => #load REG bswap(chop(WIDTH), W)      ... </k> requires WIDTH >=Int 0
+    rule <k> #exec REG = bswap WIDTH , W => #exception USER_ERROR                ... </k> requires WIDTH <Int 0
 
     rule <k> #exec REG = log2 W => #load REG log2Int(W)  ... </k> requires W >Int 0
     rule <k> #exec REG = log2 W => #exception USER_ERROR ... </k> requires W <=Int 0

--- a/tests/iele/danse/unit/exceptions.iele.json
+++ b/tests/iele/danse/unit/exceptions.iele.json
@@ -90,8 +90,8 @@
                     },
                     {
                         "out": [],
-                        "status": "0x04",
-                        "gas": "",
+                        "status": "",
+                        "gas": "0x0fab8d",
                         "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
                         "refund": ""
                     },


### PR DESCRIPTION
This PR removes an artificial limitation on the semantics of the `bswap` instruction, namely the instruction now can be applied to a negative integer argument.