### PR TITLE
make it impossible to fake a predefined exit status using revert

### DIFF
--- a/iele.md
+++ b/iele.md
@@ -1022,6 +1022,9 @@ When execution of the callee reaches a `ret` instruction, control returns to the
 
     rule <k> #exec revert VALUE => #revert VALUE ... </k>
          <output> _ => .Ints </output>
+      requires VALUE <Int 0 orBool VALUE >Int 9
+    rule <k> #exec revert VALUE => #exception USER_ERROR ...</k>
+      requires VALUE >=Int 0 andBool VALUE <=Int 9
 ```
 
 ### Log Operations


### PR DESCRIPTION
We need to make this change so it's always possible for people to tell whether a revert actually occurred. @theo25 , can you test out this change against the solidity test suite and let me know if there is a problem? I'd also like your feedback on whether this is going to cause problems for how we encode the revert builtin in Solidity. We may need to change that somehow.