### PR TITLE
Adding a new RPC end point to access blockhashes

### DIFF
--- a/vm/ieleApi.ml
+++ b/vm/ieleApi.ml
@@ -74,6 +74,10 @@ let get_account_field address blocknumber field convert default =
 let eth_getCode address blocknumber = 
   `String (get_account_field address blocknumber "code" to_string "0x")
 
+let eth_getBlockhash offset =
+  let hash = IeleClientUtils.InMemoryWorldState.get_blockhash (int_of_string offset) in
+  `String (to_hex_unsigned hash)
+
 let eth_getBlockByNumber blocknumber =
   let block = get_block blocknumber in
   `Assoc [("timestamp", `String block.timestamp)]

--- a/vm/ieleApi.mli
+++ b/vm/ieleApi.mli
@@ -1,6 +1,7 @@
 open Yojson.Basic
 
 val eth_getCode : string -> string -> json
+val eth_getBlockhash : string -> json
 val eth_getBlockByNumber : string -> json
 val eth_getTransactionReceipt : string -> json
 val iele_sendTransaction : json -> json

--- a/vm/ieleApiClient.ml
+++ b/vm/ieleApiClient.ml
@@ -20,6 +20,7 @@ let process_requests (_in,fd) =
       let params = request |> member "params" |> to_list in
       let response = match _method, params with
       | "eth_getCode", [`String address; `String number] -> eth_getCode address number
+      | "eth_getBlockhash", [`String offset] -> eth_getBlockhash offset
       | "eth_getBlockByNumber", [`String number; `Bool _] -> eth_getBlockByNumber number
       | "eth_getTransactionReceipt", [`String hash] -> eth_getTransactionReceipt hash
       | "iele_sendTransaction", [tx] -> iele_sendTransaction tx


### PR DESCRIPTION
This PR adds a new end point (`eth_getBlockhash`) to the `iele-test-client`, which allows access to the list of block hashes.