### PR TITLE
Build cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.build
+/iele-assemble/.build
 /tests/VMTests
 /tests/BlockchainTests
 /tests/**/*.test-assembled

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,10 +47,10 @@ pipeline {
       stages {
         stage('Checkout SCM') { steps { dir("kiele-${KIELE_VERSION}-src") { checkout scm } } }
         stage('Binary Package') {
-          when {
-            branch 'master'
-            beforeAgent true
-          }
+          //when {
+          //  branch 'master'
+          //  beforeAgent true
+          //}
           agent {
             dockerfile {
               additionalBuildArgs '--build-arg K_COMMIT=${K_VERSION} --build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
@@ -111,10 +111,10 @@ pipeline {
           }
         }
         stage('Ubuntu Focal') {
-          when {
-            branch 'master'
-            beforeAgent true
-          }
+          //when {
+          //  branch 'master'
+          //  beforeAgent true
+          //}
           post { failure { slackSend color: '#cb2431' , channel: '#iele-internal' , message: "Packaging Phase Failed: ${env.BUILD_URL}" } }
           stages {
             stage('Build Package') {
@@ -160,10 +160,10 @@ pipeline {
           }
         }
         stage('DockerHub') {
-          when {
-            branch 'master'
-            beforeAgent true
-          }
+          //when {
+          //  branch 'master'
+          //  beforeAgent true
+          //}
           post { failure { slackSend color: '#cb2431' , channel: '#iele-internal' , message: "Packaging Phase Failed: ${env.BUILD_URL}" } }
           environment {
             DOCKERHUB_TOKEN   = credentials('rvdockerhub')

--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,8 @@ INSTALL_PREFIX := /usr/local
 INSTALL_BIN    ?= $(DESTDIR)$(INSTALL_PREFIX)/bin
 INSTALL_LIB    ?= $(DESTDIR)$(INSTALL_PREFIX)/lib/kiele
 
-IELE_DIR      := .
-BUILD_DIR     := .build
-BUILD_LOCAL   := $(BUILD_DIR)/local
-LOCAL_LIB     := $(BUILD_LOCAL)/lib
-LOCAL_INCLUDE := $(BUILD_LOCAL)/include
+IELE_DIR  := .
+BUILD_DIR := .build
 
 KIELE_VERSION     ?= 0.2.0
 KIELE_RELEASE_TAG ?= v$(KIELE_VERSION)-$(shell git rev-parse --short HEAD)

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ UNAME_S := $(shell uname -s)
 INSTALL := install -D
 
 ifeq ($(UNAME_S),Darwin)
+INSTALL=install
 CPATH=/usr/local/include
 export CPATH
 endif
@@ -23,16 +24,9 @@ OCAMLC=opt -O3
 LIBFLAG=-shared
 endif
 
-ifeq ($(COVERAGE),k)
-KOMPILE_FLAGS=--coverage
-else ifeq ($(COVERAGE),ocaml)
-BISECT=-package bisect_ppx
-PREDICATES=-predicates coverage
-endif
-
-ifneq ($(RELEASE),)
-KOMPILE_FLAGS+=-O3
-endif
+INSTALL_PREFIX := /usr/local
+INSTALL_BIN    ?= $(DESTDIR)$(INSTALL_PREFIX)/bin
+INSTALL_LIB    ?= $(DESTDIR)$(INSTALL_PREFIX)/lib/kiele
 
 IELE_DIR       := $(abspath .)
 BUILD_DIR      := $(abspath .build)
@@ -40,6 +34,9 @@ KORE_SUBMODULE := $(BUILD_DIR)/kore
 BUILD_LOCAL    := $(BUILD_DIR)/local
 LOCAL_LIB      := $(BUILD_LOCAL)/lib
 LOCAL_INCLUDE  := $(BUILD_LOCAL)/include
+
+KIELE_VERSION     ?= 0.2.0
+KIELE_RELEASE_TAG ?= v$(KIELE_VERSION)-$(shell git rev-parse --short HEAD)
 
 PLUGIN=$(IELE_DIR)/plugin
 PROTO=$(IELE_DIR)/proto
@@ -299,6 +296,16 @@ checker_files:=$(addprefix $(IELE_DIR)/,iele-syntax.md well-formedness.md data.m
 # LLVM Builds
 # -----------
 
+ifeq ($(COVERAGE),k)
+KOMPILE_FLAGS=--coverage
+else ifeq ($(COVERAGE),ocaml)
+PREDICATES=-predicates coverage
+endif
+
+ifneq ($(RELEASE),)
+KOMPILE_FLAGS+=-O3
+endif
+
 LIB_PROCPS=-lprocps
 
 ifeq ($(UNAME_S),Darwin)
@@ -396,17 +403,6 @@ coverage:
 
 # Install
 # -------
-
-ifeq ($(UNAME_S),Darwin)
-INSTALL=install
-endif
-
-KIELE_VERSION     ?= 0.2.0
-KIELE_RELEASE_TAG ?= v$(KIELE_VERSION)-$(shell git rev-parse --short HEAD)
-
-INSTALL_PREFIX := /usr/local
-INSTALL_BIN    ?= $(DESTDIR)$(INSTALL_PREFIX)/bin
-INSTALL_LIB    ?= $(DESTDIR)$(INSTALL_PREFIX)/lib/kiele
 
 install_bins :=      \
     iele-assemble    \

--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,11 @@ INSTALL_PREFIX := /usr/local
 INSTALL_BIN    ?= $(DESTDIR)$(INSTALL_PREFIX)/bin
 INSTALL_LIB    ?= $(DESTDIR)$(INSTALL_PREFIX)/lib/kiele
 
-IELE_DIR       := $(abspath .)
-BUILD_DIR      := $(abspath .build)
-KORE_SUBMODULE := $(BUILD_DIR)/kore
-BUILD_LOCAL    := $(BUILD_DIR)/local
-LOCAL_LIB      := $(BUILD_LOCAL)/lib
-LOCAL_INCLUDE  := $(BUILD_LOCAL)/include
+IELE_DIR      := .
+BUILD_DIR     := .build
+BUILD_LOCAL   := $(BUILD_DIR)/local
+LOCAL_LIB     := $(BUILD_LOCAL)/lib
+LOCAL_INCLUDE := $(BUILD_LOCAL)/include
 
 KIELE_VERSION     ?= 0.2.0
 KIELE_RELEASE_TAG ?= v$(KIELE_VERSION)-$(shell git rev-parse --short HEAD)
@@ -41,8 +40,8 @@ KIELE_RELEASE_TAG ?= v$(KIELE_VERSION)-$(shell git rev-parse --short HEAD)
 PLUGIN=$(IELE_DIR)/plugin
 PROTO=$(IELE_DIR)/proto
 
-IELE_BIN         := $(BUILD_DIR)/bin
-IELE_LIB         := $(BUILD_DIR)/lib/kiele
+IELE_BIN         := $(BUILD_LOCAL)$(INSTALL_BIN)
+IELE_LIB         := $(BUILD_LOCAL)$(INSTALL_LIB)
 IELE_RUNNER      := $(IELE_BIN)/kiele
 IELE_ASSEMBLE    := $(IELE_BIN)/iele-assemble
 IELE_INTERPRETER := $(IELE_BIN)/iele-interpreter

--- a/kiele
+++ b/kiele
@@ -5,8 +5,8 @@ set -euo pipefail
 notif() { echo "== $@" >&2 ; }
 fatal() { echo "[FATAL] $@" ; exit 1 ; }
 
-INSTALL_BIN="$(dirname $0)"
-INSTALL_LIB=${INSTALL_BIN}/../lib/kiele
+INSTALL_BIN="$(cd $(dirname $0) && pwd)"
+INSTALL_LIB="$(dirname ${INSTALL_BIN})/lib/kevm"
 FIREFLY_ENDPOINT=${FIREFLY_ENDPOINT:-https://fireflyblockchain.com}
 
 export PATH="$INSTALL_BIN:$INSTALL_LIB:$PATH"


### PR DESCRIPTION
These cleanups are largely needed to get KIELE building with the newest K releases, but should also be standalone.