### PR TITLE
fix: add meta.description to kiele

### DIFF
--- a/nix/kiele.nix
+++ b/nix/kiele.nix
@@ -81,4 +81,5 @@ stdenv.mkDerivation {
     ln -s ${lib.getLib iele-check}/lib/kiele/check $out/lib/kiele
   '';
   passthru = { inherit iele-assemble iele-check iele-interpreter iele-vm; };
+  meta.description = "A cli tool for interactig with iele";
 }


### PR DESCRIPTION
numtide/devshell grabs this value for it's motd

kiele dosn't currently say what it's doing:

![image](https://user-images.githubusercontent.com/7548295/132248444-a4d24ff7-f806-433f-8a66-990730b0a543.png)
