### PR TITLE
Bump Z3 version to 4.8.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,15 @@ RUN    apt update         \
         python3-pip       \
         zlib1g-dev
 
+RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.12 \
+    && cd z3                                                         \
+    && python scripts/mk_make.py                                     \
+    && cd build                                                      \
+    && make -j8                                                      \
+    && make install                                                  \
+    && cd ../..                                                      \
+    && rm -rf z3
+
 RUN curl -sSL https://get.haskellstack.org/ | sh
 
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN    apt update         \
         python3-pip       \
         zlib1g-dev
 
-RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.12 \
+RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.11 \
     && cd z3                                                         \
     && python scripts/mk_make.py                                     \
     && cd build                                                      \


### PR DESCRIPTION
This reflects a change in the downstream K distribution; the main PR is at https://github.com/kframework/k/pull/2225