### PR TITLE
Bump CI action versions, pin nix to 2.3.16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,9 @@ jobs:
           submodules: recursive
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v12
+        uses: cachix/install-nix-action@v14.1
+        with:
+          install_url: "https://releases.nixos.org/nix/nix-2.3.16/install"
 
       - name: Upload release.nix
         uses: ttuegel/upload-release.nix@v1.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
 
     - name: Build
-      run: nix-build --cores 1
+      run: K_OPTS=-Xmx6G nix-build --cores 1
 
     - name: Run unit tests
       run: nix-build iele-assemble -A project.iele-assemble.checks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,14 +14,15 @@ jobs:
         submodules: recursive
 
     - name: Install Nix
-      uses: cachix/install-nix-action@v12
+      uses: cachix/install-nix-action@v14.1
       with:
         extra_nix_config: |
           substituters = http://cache.nixos.org https://hydra.iohk.io
           trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
+        install_url: "https://releases.nixos.org/nix/nix-2.3.16/install"
 
     - name: Install Cachix
-      uses: cachix/cachix-action@v8
+      uses: cachix/cachix-action@v10
       with:
         name: runtimeverification
         extraPullNames: kore
@@ -44,14 +45,15 @@ jobs:
         submodules: recursive
 
     - name: Install Nix
-      uses: cachix/install-nix-action@v12
+      uses: cachix/install-nix-action@v14.1
       with:
         extra_nix_config: |
           substituters = http://cache.nixos.org https://hydra.iohk.io
           trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
+        install_url: "https://releases.nixos.org/nix/nix-2.3.16/install"
 
     - name: Install Cachix
-      uses: cachix/cachix-action@v8
+      uses: cachix/cachix-action@v10
       with:
         name: runtimeverification
         extraPullNames: kore

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -28,11 +28,12 @@ jobs:
           submodules: recursive
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v12
+        uses: cachix/install-nix-action@v14.1
         with:
           extra_nix_config: |
             substituters = http://cache.nixos.org https://hydra.iohk.io
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
+          install_url: "https://releases.nixos.org/nix/nix-2.3.16/install"
 
       - name: Materialize
         run: ./nix/rematerialize.sh

--- a/nix/kiele.nix
+++ b/nix/kiele.nix
@@ -43,9 +43,6 @@ let
       ];
     buildFlags = [ "build-${target}" ];
     installTargets = [ "install-${target}" ];
-    buildPhase = ''
-      K_OPTS=-Xmx6G make
-    '';
   });
 
   iele-interpreter = mkIELE "interpreter" (x: x);

--- a/nix/kiele.nix
+++ b/nix/kiele.nix
@@ -43,6 +43,9 @@ let
       ];
     buildFlags = [ "build-${target}" ];
     installTargets = [ "install-${target}" ];
+    buildPhase = ''
+      K_OPTS=-Xmx6G make
+    '';
   });
 
   iele-interpreter = mkIELE "interpreter" (x: x);


### PR DESCRIPTION
This PR is a fix for CI failures related to a new Nix release yesterday. It does two things:
* Bumps the github actions we use for nix (`install-nix`, `install-cachix`) to their newest versions.
* Pins Nix to 2.3.16 as a temporary fix, as 2.4 breaks on macos at the moment.