### PR TITLE
Bump Z3 version to 4.8.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN    apt update         \
         python3-pip       \
         zlib1g-dev
 
-RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.11 \
+RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.15 \
     && cd z3                                                         \
     && python scripts/mk_make.py                                     \
     && cd build                                                      \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -145,7 +145,7 @@ Releases are available for download here: <https://github.com/kframework/k/tags>
 
 ### Z3
 
-KIELE requires Z3 version 4.8.11, which you may need to install from a source
+KIELE requires Z3 version 4.8.15, which you may need to install from a source
 build if your package manager supplies a different version. To do so, follow the
 instructions
 [here](https://github.com/Z3Prover/z3#building-z3-using-make-and-gccclang) after
@@ -154,7 +154,7 @@ checking out the correct tag in the Z3 repository:
 ```sh
 git clone https://github.com/Z3Prover/z3.git
 cd z3
-git checkout z3-4.8.11
+git checkout z3-4.8.15
 python scripts/mk_make.py
 cd build
 make


### PR DESCRIPTION
This PR reflects a pending change in the upstream K distribution; it updates package files and documentation to reflect the new version of Z3 we require.